### PR TITLE
AML-243 - Queue name renaming for environment consistency

### DIFF
--- a/src/SFA.DAS.EAS.Notification.Worker/Providers/Notification.cs
+++ b/src/SFA.DAS.EAS.Notification.Worker/Providers/Notification.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.EAS.Notification.Worker.Providers
     public class Notification : INotification
     {
         [QueueName]
-        public string das_at_eas_send_notification { get; set; }
+        public string send_notification { get; set; }
 
         private readonly ILogger _logger;
         private readonly IPollingMessageReceiver _pollingMessageReceiver;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/CreateEmployerAccount/CreateAccountCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/CreateEmployerAccount/CreateAccountCommandHandler.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.EmployerApprenticeshipsService.Application.Commands.CreateEmpl
     public class CreateAccountCommandHandler : AsyncRequestHandler<CreateAccountCommand>
     {
         [QueueName]
-        public string das_at_eas_get_employer_levy { get; set; }
+        public string get_employer_levy { get; set; }
 
         private readonly IAccountRepository _accountRepository;
         private readonly IMessagePublisher _messagePublisher;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RefreshEmployerLevyData/RefreshEmployerLevyDataCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RefreshEmployerLevyData/RefreshEmployerLevyDataCommandHandler.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.EmployerApprenticeshipsService.Application.Commands.RefreshEmp
     public class RefreshEmployerLevyDataCommandHandler : AsyncRequestHandler<RefreshEmployerLevyDataCommand>
     {
         [QueueName]
-        public string das_at_eas_refresh_employer_levy { get; set; }
+        public string refresh_employer_levy { get; set; }
 
         private readonly IValidator<RefreshEmployerLevyDataCommand> _validator;
         private readonly IDasLevyRepository _dasLevyRepository;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/SendNotification/SendNotificationCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/SendNotification/SendNotificationCommandHandler.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.EmployerApprenticeshipsService.Application.Commands.SendNotifi
     {
 
         [QueueName]
-        public string das_at_eas_send_notification { get; set; }
+        public string send_notification { get; set; }
 
         private readonly IValidator<SendNotificationCommand> _validator;
         private readonly ILogger _logger;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Configuration/EmployerApprenticeshipsServiceConfiguration.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Configuration/EmployerApprenticeshipsServiceConfiguration.cs
@@ -40,14 +40,7 @@ namespace SFA.DAS.EmployerApprenticeshipsService.Domain.Configuration
     {
         public string ApiKey { get; set; }
     }
-    
-    public static class QueueNames
-    {
-        public static string das_at_eas_refresh_employer_levy { get; set; }
-        public static string das_at_eas_get_employer_levy  { get; set; }
-        
-    }
-
+   
     public class SmtpConfiguration
     {
         public string ServerName { get; set; }

--- a/src/SFA.DAS.LevyAggregationProvider.Worker/Providers/LevyAggregationManager.cs
+++ b/src/SFA.DAS.LevyAggregationProvider.Worker/Providers/LevyAggregationManager.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.LevyAggregationProvider.Worker.Providers
     public class LevyAggregationManager
     {
         [QueueName]
-        public string das_at_eas_refresh_employer_levy { get; set; }
+        public string refresh_employer_levy { get; set; }
 
         private readonly IPollingMessageReceiver _pollingMessageReceiver;
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/Providers/LevyDeclaration.cs
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/Providers/LevyDeclaration.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.LevyDeclarationProvider.Worker.Providers
     public class LevyDeclaration : ILevyDeclaration
     {
         [QueueName]
-        public string das_at_eas_get_employer_levy { get; set; }
+        public string get_employer_levy { get; set; }
 
         private readonly IPollingMessageReceiver _pollingMessageReceiver;
         private readonly IMediator _mediator;


### PR DESCRIPTION
Update all queue names to remove the das_at_eas_ part from the queue name. Also removed an non-used class that was being used to define the queue names before the MessagePolicy was introduced.