### PR TITLE
Aml 754 periodend with no dates

### DIFF
--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob/Updater/PaymentProcessor.cs
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob/Updater/PaymentProcessor.cs
@@ -75,7 +75,12 @@ namespace SFA.DAS.EAS.PaymentUpdater.WebJob.Updater
             {
                 _logger.Info($"Creating period end {periodEnd.Id}");
                 await _mediator.SendAsync(new CreateNewPeriodEndCommand {NewPeriodEnd = periodEnd});
-                
+
+                if (periodEnd.ReferenceData?.AccountDataValidAt == null || periodEnd.ReferenceData?.CommitmentDataValidAt == null)
+                {
+                    continue;
+                }
+
                 foreach (var account in response.Accounts)
                 {
                     _logger.Info($"Createing payment queue message for accountId:{account.Id} periodEndId:{periodEnd.Id}");

--- a/src/SFA.DAS.EmployerApprenticeshipService.HMRC.Database/StoredProcedures/CreatePeriodEnd.sql
+++ b/src/SFA.DAS.EmployerApprenticeshipService.HMRC.Database/StoredProcedures/CreatePeriodEnd.sql
@@ -2,8 +2,8 @@
 	@PeriodEndId nvarchar(20),
 	@CalendarPeriodMonth int,
 	@CalendarPeriodYear int,
-	@AccountDataValidAt datetime,
-	@CommitmentDataValidAt datetime,
+	@AccountDataValidAt datetime = null,
+	@CommitmentDataValidAt datetime = null,
 	@CompletionDateTime datetime,
 	@PaymentsForPeriod nvarchar(250)
 AS

--- a/src/SFA.DAS.EmployerApprenticeshipService.HMRC.Database/Tables/PeriodEnd.sql
+++ b/src/SFA.DAS.EmployerApprenticeshipService.HMRC.Database/Tables/PeriodEnd.sql
@@ -4,8 +4,8 @@
 	[PeriodEndId] nvarchar(20) NOT NULL,
 	[CalendarPeriodMonth] int not null,
 	[CalendarPeriodYear] int not null,
-	[AccountDataValidAt] Datetime not null,
-	[CommitmentDataValidAt] Datetime not null,
+	[AccountDataValidAt] Datetime null,
+	[CommitmentDataValidAt] Datetime null,
 	[CompletionDateTime] Datetime not null,
 	[PaymentsForPeriod] nvarchar(250) not null
 )


### PR DESCRIPTION
Fix made so that if there are no reference data completion dates then no payment messages will be created. Stored procedure for creating period ends and table updated