### PR TITLE
Aml 763 invitation all page updates

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
@@ -48,9 +48,9 @@ namespace SFA.DAS.EAS.Web.Controllers
 
             _employerAccountOrchestrator.DeleteCookieData(HttpContext);
 
-            var model = new OrchestratorResponse<SelectEmployerModel>
+            var model = new OrchestratorResponse<SelectEmployerViewModel>
             {
-                Data = new SelectEmployerModel
+                Data = new SelectEmployerViewModel
                 {
                     HideBreadcrumb = hideBreadcrumb
                 }

--- a/src/SFA.DAS.EAS.Web/Orchestrators/InvitationOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/InvitationOrchestrator.cs
@@ -6,6 +6,7 @@ using SFA.DAS.EAS.Application;
 using SFA.DAS.EAS.Application.Commands.AcceptInvitation;
 using SFA.DAS.EAS.Application.Commands.CreateInvitation;
 using SFA.DAS.EAS.Application.Queries.GetInvitation;
+using SFA.DAS.EAS.Application.Queries.GetUserAccounts;
 using SFA.DAS.EAS.Application.Queries.GetUserInvitations;
 using SFA.DAS.EAS.Domain;
 using SFA.DAS.EAS.Domain.ViewModels;
@@ -74,7 +75,14 @@ namespace SFA.DAS.EAS.Web.Orchestrators
                     UserId = externalUserId
                 });
 
-                return new UserInvitationsViewModel {Invitations = response.Invitations };
+                var getUserAccountsQueryResponse = await _mediator.SendAsync(new GetUserAccountsQuery
+                {
+                    UserId = externalUserId
+                });
+
+                return new UserInvitationsViewModel {
+                    Invitations = response.Invitations,
+                    ShowBreadCrumbs = getUserAccountsQueryResponse.Accounts.AccountList.Count!=0 };
             }
             catch (InvalidRequestException ex)
             {

--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccount/SelectEmployer.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccount/SelectEmployer.cshtml
@@ -1,7 +1,7 @@
 ﻿@{ViewBag.PageID = "page-onboard-companies-house"; }
 @{ViewBag.Title = "Enter your Companies House number"; }
 
-@model SFA.DAS.EAS.Web.OrchestratorResponse<SFA.DAS.EAS.Web.Models.SelectEmployerModel>
+@model SFA.DAS.EAS.Web.OrchestratorResponse<SFA.DAS.EAS.Web.Models.SelectEmployerViewModel>
 
 
 @if (TempData["companyNumberError"] != null)

--- a/src/SFA.DAS.EAS.Web/Views/Invitation/All.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Invitation/All.cshtml
@@ -60,12 +60,15 @@
     </div>
 </div>
 
-
-@section breadcrumb {
-    <div class="breadcrumbs">
-        <ol role="navigation">
-            <li><a href="/">Your User Profile</a></li>
-            <li>Invitations</li>
-        </ol>
-    </div>
+@if (Model.ShowBreadCrumbs)
+{
+    @section breadcrumb {
+        <div class="breadcrumbs">
+            <ol role="navigation">
+                <li><a href="/">Your User Profile</a></li>
+                <li>Invitations</li>
+            </ol>
+        </div>
+    }
 }
+

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/ViewModels/UserInvitationsViewModel.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/ViewModels/UserInvitationsViewModel.cs
@@ -5,5 +5,6 @@ namespace SFA.DAS.EAS.Domain.ViewModels
     public class UserInvitationsViewModel
     {
         public List<InvitationView> Invitations { get; set; }
+        public bool ShowBreadCrumbs { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountControllerTests/WhenIStartTheProcess.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountControllerTests/WhenIStartTheProcess.cs
@@ -142,7 +142,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.EmployerAccountControllerTests
             Assert.IsNotNull(actual);
             var actualViewResult = actual as ViewResult;
             Assert.IsNotNull(actualViewResult);
-            var actualModel = actualViewResult.Model as OrchestratorResponse<SelectEmployerModel>;
+            var actualModel = actualViewResult.Model as OrchestratorResponse<SelectEmployerViewModel>;
             Assert.IsNotNull(actualModel);
             Assert.IsTrue(actualModel.Data.HideBreadcrumb);
         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/InvitationOrchestratorTests/WhenGettingAllInvitations.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/InvitationOrchestratorTests/WhenGettingAllInvitations.cs
@@ -10,6 +10,7 @@ using SFA.DAS.EAS.Application;
 using SFA.DAS.EAS.Application.Queries.GetUserAccounts;
 using SFA.DAS.EAS.Application.Queries.GetUserInvitations;
 using SFA.DAS.EAS.Domain;
+using SFA.DAS.EAS.Domain.Entities.Account;
 using SFA.DAS.EAS.Domain.ViewModels;
 using SFA.DAS.EAS.Web.Orchestrators;
 
@@ -26,6 +27,10 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.InvitationOrchestratorTests
         {
             _mediator = new Mock<IMediator>();
             _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserInvitationsRequest>())).ReturnsAsync(new GetUserInvitationsResponse {Invitations = new List<InvitationView> {new InvitationView()} });
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserAccountsQuery>())).ReturnsAsync(new GetUserAccountsQueryResponse
+                {
+                    Accounts = new Accounts {AccountList = new List<Account>()}
+                });
 
             _logger = new Mock<ILogger>();
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/InvitationOrchestratorTests/WhenGettingAllInvitations.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/InvitationOrchestratorTests/WhenGettingAllInvitations.cs
@@ -7,6 +7,7 @@ using Moq;
 using NLog;
 using NUnit.Framework;
 using SFA.DAS.EAS.Application;
+using SFA.DAS.EAS.Application.Queries.GetUserAccounts;
 using SFA.DAS.EAS.Application.Queries.GetUserInvitations;
 using SFA.DAS.EAS.Domain;
 using SFA.DAS.EAS.Domain.ViewModels;
@@ -78,6 +79,19 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.InvitationOrchestratorTests
             //Assert
             Assert.IsNull(actual);
             _logger.Verify(x=>x.Info(It.IsAny<InvalidRequestException>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ThenICheckToSeeWhatAccountsIHaveAccessTo()
+        {
+            //Arrange
+            var expectedUserId = "123FVD";
+
+            //Act
+            await _invitationOrchestrator.GetAllInvitationsForUser(expectedUserId);
+
+            //Assert
+            _mediator.Verify(x => x.SendAsync(It.Is<GetUserAccountsQuery>(c => c.UserId.Equals(expectedUserId))), Times.Once);
         }
     }
 }


### PR DESCRIPTION
The breadcrumbs on the invitation all page will now only show if you have 1 or more accounts already associated to your account