### PR TITLE
Correct cookie url

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
@@ -81,7 +81,7 @@
     <div id="global-cookie-message">
 
         <p>
-            GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
+            GOV.UK uses cookies to make the site simpler. <a href="@Url.Action("Privacy","Home")">Find out more about cookies</a>
         </p>
 
     </div>


### PR DESCRIPTION
Corrected the URL that the user is redirected to for viewing the
Privacy and Cookies page