### PR TITLE
Change the invite team member to redirect

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerTeamController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerTeamController.cs
@@ -39,7 +39,9 @@ namespace SFA.DAS.EAS.Web.Controllers
         [Route("Teams")]
         public async Task<ActionResult> ViewTeam(string hashedAccountId)
         {
-            var response = await _employerTeamOrchestrator.GetTeamMembers(hashedAccountId, OwinWrapper.GetClaimValue(@"sub"));
+            var userAddedEmail = TempData.ContainsKey("userAdded") ? TempData["userAdded"].ToString() : string.Empty;
+            
+            var response = await _employerTeamOrchestrator.GetTeamMembers(hashedAccountId, OwinWrapper.GetClaimValue(@"sub"), userAddedEmail);
 
             return View(response);
         }
@@ -62,8 +64,8 @@ namespace SFA.DAS.EAS.Web.Controllers
 
             if (response.Status == HttpStatusCode.OK)
             {
-                TempData["userAdded"] = "true";
-                return View("ViewTeam", response);
+                TempData["userAdded"] = model.Email;
+                return RedirectToAction("ViewTeam");
             }
                 
            

--- a/src/SFA.DAS.EAS.Web/Orchestrators/EmployerTeamOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/EmployerTeamOrchestrator.cs
@@ -59,7 +59,7 @@ namespace SFA.DAS.EAS.Web.Orchestrators
         }
 
         public async Task<OrchestratorResponse<EmployerTeamMembersViewModel>> GetTeamMembers(
-            string hashedId, string userId)
+            string hashedId, string userId, string userAdded="")
         {
             try
             {
@@ -71,6 +71,18 @@ namespace SFA.DAS.EAS.Web.Orchestrators
                             ExternalUserId = userId
                         });
 
+                var flashMessage = new FlashMessageViewModel();
+
+                if (!string.IsNullOrWhiteSpace(userAdded))
+                {
+                    flashMessage = new FlashMessageViewModel
+                    {
+                        Severity = FlashMessageSeverityLevel.Success,
+                        Headline = "Invitation sent",
+                        Message = $"You've sent an invitation to <strong>{userAdded}</strong>"
+                    };
+                }
+
                 return new OrchestratorResponse<EmployerTeamMembersViewModel>
                 {
                     Status = HttpStatusCode.OK,
@@ -78,7 +90,8 @@ namespace SFA.DAS.EAS.Web.Orchestrators
                     {
                         HashedAccountId = hashedId,
                         TeamMembers = response.TeamMembers
-                    }
+                    },
+                    FlashMessage = flashMessage
                 };
             }
             catch (InvalidRequestException ex)
@@ -137,19 +150,9 @@ namespace SFA.DAS.EAS.Web.Orchestrators
                 };
             }
 
-            var response = await GetTeamMembers(model.HashedAccountId, externalUserId);
+            
 
-            if (response.Status == HttpStatusCode.OK)
-            {
-                response.FlashMessage = new FlashMessageViewModel
-                {
-                    Severity = FlashMessageSeverityLevel.Success,
-                    Headline = "Invitation sent",
-                    Message = $"You've sent an invitation to <strong>{model.Email}</strong>"
-                };
-            }
-
-            return response;
+            return new OrchestratorResponse<EmployerTeamMembersViewModel>();
         }
 
         public async Task<OrchestratorResponse<InvitationViewModel>> Review(

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetMyTeamMembers.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetMyTeamMembers.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Application.Queries.GetAccountTeamMembers;
+using SFA.DAS.EAS.Domain;
+using SFA.DAS.EAS.Web.Orchestrators;
+
+namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
+{
+    public class WhenIGetMyTeamMembers
+    {
+        private Mock<IMediator> _mediator;
+        private EmployerTeamOrchestrator _orchestrator;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _mediator = new Mock<IMediator>();
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetAccountTeamMembersQuery>())).ReturnsAsync(new GetAccountTeamMembersResponse {TeamMembers = new List<TeamMember> {new TeamMember()} });
+
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object);
+        }
+
+        [Test]
+        public async Task ThenTheGetTeamMembersCallWillShowASuccessMessageIfAnEmailHasBeenPassed()
+        {
+            //Arrange
+            var expectedEmail = "test@test.com";
+
+            //Act
+            var actual = await _orchestrator.GetTeamMembers("ABF45", "123", expectedEmail);
+
+            //Assert
+            Assert.IsNotNull(actual.FlashMessage);
+            Assert.AreEqual("Invitation sent", actual.FlashMessage.Headline);
+            Assert.AreEqual($"You've sent an invitation to <strong>{expectedEmail}</strong>", actual.FlashMessage.Message);
+        }
+
+        [Test]
+        public async Task ThenTheTeamMembersArePopulatedToTheResponse()
+        {
+            //Act
+            var actual = await _orchestrator.GetTeamMembers("ABF45", "123");
+
+            //Assert
+            Assert.IsNotEmpty(actual.Data.TeamMembers);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIInviteATeamMember.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIInviteATeamMember.cs
@@ -46,9 +46,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
             //Assert
             Assert.IsNotNull(result);
             Assert.AreEqual(HttpStatusCode.OK, result.Status);
-            Assert.IsNotNull(result.FlashMessage);
-            Assert.AreEqual("Invitation sent", result.FlashMessage.Headline);
-            Assert.AreEqual($"You've sent an invitation to <strong>{request.Email}</strong>", result.FlashMessage.Message);
+            
         }
 
         [Test]
@@ -96,28 +94,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
             Assert.AreEqual(HttpStatusCode.Unauthorized, result.Status);
             _mediator.Verify(x => x.SendAsync(It.IsAny<GetAccountTeamMembersQuery>()), Times.Never);
         }
-
-        [Test]
-        public async Task ThenIShouldGetBackABadRequestIfOneIsRaiseForViewingTeamMembers()
-        {
-            //Arrange
-            var request = new InviteTeamMemberViewModel
-            {
-                Email = "test@test.com"
-            };
-          
-            _mediator.Setup(x => x.SendAsync(It.IsAny<CreateInvitationCommand>())).ReturnsAsync(Unit.Value);
-            _mediator.Setup(x => x.SendAsync(It.IsAny<GetAccountTeamMembersQuery>()))
-                     .ThrowsAsync(new InvalidRequestException(new Dictionary<string, string>()));
-
-            //Act
-            var result = await _orchestrator.InviteTeamMember(request, "37648");
-
-            //Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual(HttpStatusCode.BadRequest, result.Status);
-        }
-
+        
         
         [TestCase(Role.Viewer, HttpStatusCode.Unauthorized)]
         [TestCase(Role.Transactor, HttpStatusCode.Unauthorized)]
@@ -140,5 +117,6 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
             //Assert
             Assert.AreEqual(status, result.Status);
         }
+        
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Orchestrators\EmployerCommitmentOrchestrator\WhenGettingStatusOfCommitment.cs" />
     <Compile Include="Orchestrators\EmployerTeamOrchestratorTests\WhenIChangeATeamMemberRole.cs" />
     <Compile Include="Orchestrators\EmployerTeamOrchestratorTests\WhenIGetATeamMembersDetails.cs" />
+    <Compile Include="Orchestrators\EmployerTeamOrchestratorTests\WhenIGetMyTeamMembers.cs" />
     <Compile Include="Orchestrators\EmployerTeamOrchestratorTests\WhenIInviteATeamMember.cs" />
     <Compile Include="Orchestrators\EmployerTeamOrchestratorTests\WhenIRemoveATeamMember.cs" />
     <Compile Include="Orchestrators\HmrcOrchestratorTests\WhenCallingHmrcService.cs" />


### PR DESCRIPTION
Change the logic so it redirects back to the team member page with a
tempdata value to indicate what email should be displayed as being
added. This corrects the problem with refreshing the page