### PR TITLE
Added support for the Public Organisaions API methods

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetPublicSectorOrgainsationTests/WhenIGetPublicSectorOrgainsations.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetPublicSectorOrgainsationTests/WhenIGetPublicSectorOrgainsations.cs
@@ -1,0 +1,105 @@
+﻿using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation;
+using SFA.DAS.EAS.Application.Validation;
+using SFA.DAS.EAS.Domain.Interfaces;
+using SFA.DAS.EAS.Domain.Models.ReferenceData;
+
+namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetPublicSectorOrgainsationTests
+{
+    public  class WhenIGetPublicSectorOrgainsations : QueryBaseTest<
+        GetPublicSectorOrgainsationHandler,
+        GetPublicSectorOrgainsationQuery,
+        GetPublicSectorOrgainsationResponse>
+    {
+        private Mock<IReferenceDataService> _referenceDataServiceMock;
+        private PagedResponse<PublicSectorOrganisation> _organisations;
+        public override GetPublicSectorOrgainsationQuery Query { get; set; }
+        public override GetPublicSectorOrgainsationHandler RequestHandler { get; set; }
+        public override Mock<IValidator<GetPublicSectorOrgainsationQuery>> RequestValidator { get; set; }
+
+        [SetUp]
+        public void Arrange()
+        {
+            SetUp();
+
+            _organisations = new PagedResponse<PublicSectorOrganisation>();
+
+            _referenceDataServiceMock = new Mock<IReferenceDataService>();
+
+            _referenceDataServiceMock.Setup(x => x.SearchPublicSectorOrganisation(It.IsAny<string>()))
+                                     .ReturnsAsync(_organisations);
+            _referenceDataServiceMock.Setup(x => x.SearchPublicSectorOrganisation(
+                                                    It.IsAny<string>(), It.IsAny<int>()))
+                                     .ReturnsAsync(_organisations);
+            _referenceDataServiceMock.Setup(x => x.SearchPublicSectorOrganisation(
+                                                    It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                                     .ReturnsAsync(_organisations);
+
+            Query = new GetPublicSectorOrgainsationQuery
+            {
+                SearchTerm = "test"
+            };
+            RequestHandler = new GetPublicSectorOrgainsationHandler(
+                RequestValidator.Object,
+                _referenceDataServiceMock.Object);
+        }
+
+        [Test]
+        public override async Task ThenIfTheMessageIsValidTheRepositoryIsCalled()
+        {
+            //Act
+            await RequestHandler.Handle(Query);
+
+            //Assert
+            _referenceDataServiceMock.Verify(x => x.SearchPublicSectorOrganisation(Query.SearchTerm), Times.Once);
+        }
+
+        [Test]
+        public override async Task ThenIfTheMessageIsValidTheValueIsReturnedInTheResponse()
+        {
+            //Act
+            var response = await RequestHandler.Handle(Query);
+
+            //Assert
+            Assert.AreEqual(_organisations, response.Organisaions);
+        }
+
+        [Test]
+        public async Task ThenShouldCallServiceWithPageNumberAndSizeIfProvided()
+        {
+            //Arrange
+            Query.PageNumber = 2;
+            Query.PageSize = 443;
+
+            //Act
+            await RequestHandler.Handle(Query);
+
+            //Assert
+            _referenceDataServiceMock.Verify(x => 
+                x.SearchPublicSectorOrganisation(
+                    Query.SearchTerm, 
+                    Query.PageNumber.Value, 
+                    Query.PageSize.Value), 
+                    Times.Once);
+        }
+
+        [Test]
+        public async Task ThenShouldCallServiceWithPageNumberIfProvided()
+        {
+            //Arrange
+            Query.PageNumber = 2;
+
+            //Act
+            await RequestHandler.Handle(Query);
+
+            //Assert
+            _referenceDataServiceMock.Verify(x =>
+                x.SearchPublicSectorOrganisation(
+                    Query.SearchTerm,
+                    Query.PageNumber.Value),
+                    Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetPublicSectorOrgainsationTests/WhenIValidateTheQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetPublicSectorOrgainsationTests/WhenIValidateTheQuery.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation;
+
+namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetPublicSectorOrgainsationTests
+{
+    public class WhenIValidateTheQuery
+    {
+        private GetPublicSectorOrgainsationValidator _validator;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _validator = new GetPublicSectorOrgainsationValidator();
+        }
+
+        [Test]
+        public void ThenAValidQueryShouldPassValidation()
+        {
+            //Arange
+            var query = new GetPublicSectorOrgainsationQuery
+            {
+                SearchTerm = "test",
+                PageNumber = 1,
+                PageSize = 50
+            };
+
+            //Act
+            var result = _validator.Validate(query);
+
+            //Assert
+            Assert.IsTrue(result.IsValid());
+        }
+
+        [Test]
+        public void ThenAQueryWithNoSearchTermShouldFailValidation()
+        {
+            //Arange
+            var query = new GetPublicSectorOrgainsationQuery
+            {
+                SearchTerm = null,
+                PageNumber = 1,
+                PageSize = 50
+            };
+
+            //Act
+            var result = _validator.Validate(query);
+
+            //Assert
+            Assert.IsFalse(result.IsValid());
+            Assert.Contains(new KeyValuePair<string, string>("SearchTerm", "Search term has not been supplied"), result.ValidationDictionary);
+        }
+
+        [Test]
+        public void ThenANullQueryShouldFailValidation()
+        {
+            //Act
+            var result = _validator.Validate(null);
+
+            //Assert
+            Assert.IsFalse(result.IsValid());
+            Assert.Contains(new KeyValuePair<string, string>("Query", "Query should not be null"), result.ValidationDictionary);
+
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/SFA.DAS.EAS.Application.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/SFA.DAS.EAS.Application.UnitTests.csproj
@@ -203,6 +203,8 @@
     <Compile Include="Queries\GetHmrcLevyDeclarationTests\WhenRequestingLevyDeclarations.cs" />
     <Compile Include="Queries\GetHmrcLevyDeclarationTests\WhenValidatingTheRequest.cs" />
     <Compile Include="Queries\GetPayeSchemeInUseTests\WhenIValidateTheQuery.cs" />
+    <Compile Include="Queries\GetPublicSectorOrgainsationTests\WhenIGetPublicSectorOrgainsations.cs" />
+    <Compile Include="Queries\GetPublicSectorOrgainsationTests\WhenIValidateTheQuery.cs" />
     <Compile Include="Queries\GetUserAccountRole\WhenIGetAUserAccountRole.cs" />
     <Compile Include="Queries\GetUserAccountRole\WhenIValidateTheRequest.cs" />
     <Compile Include="Queries\GetUserAccountsTests\WhenIGetUserAccounts.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationHandler.cs
@@ -1,0 +1,57 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+using SFA.DAS.EAS.Application.Validation;
+using SFA.DAS.EAS.Domain.Interfaces;
+using SFA.DAS.EAS.Domain.Models.ReferenceData;
+
+namespace SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation
+{
+    public class GetPublicSectorOrgainsationHandler : IAsyncRequestHandler<GetPublicSectorOrgainsationQuery, GetPublicSectorOrgainsationResponse>
+    {
+        private readonly IValidator<GetPublicSectorOrgainsationQuery> _requestValidator;
+        private readonly IReferenceDataService _referenceDataService;
+
+        public GetPublicSectorOrgainsationHandler(
+            IValidator<GetPublicSectorOrgainsationQuery> requestValidator, 
+            IReferenceDataService referenceDataService)
+        {
+            _requestValidator = requestValidator;
+            _referenceDataService = referenceDataService;
+        }
+
+        public async Task<GetPublicSectorOrgainsationResponse> Handle(GetPublicSectorOrgainsationQuery message)
+        {
+            var validationResult = _requestValidator.Validate(message);
+
+            if (!validationResult.IsValid())
+            {
+                throw new InvalidRequestException(validationResult.ValidationDictionary);
+            }
+
+            PagedResponse<PublicSectorOrganisation> response;
+
+            if (message.PageNumber.HasValue && message.PageSize.HasValue)
+            {
+                response = await _referenceDataService.SearchPublicSectorOrganisation(
+                    message.SearchTerm,
+                    message.PageNumber.Value,
+                    message.PageSize.Value);
+            }
+            else if (message.PageNumber.HasValue)
+            {
+                response = await _referenceDataService.SearchPublicSectorOrganisation(
+                   message.SearchTerm,
+                   message.PageNumber.Value);
+            }
+            else
+            {
+                response = await _referenceDataService.SearchPublicSectorOrganisation(message.SearchTerm);
+            }
+
+            return new GetPublicSectorOrgainsationResponse
+            {
+                Organisaions = response
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationQuery.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+
+namespace SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation
+{
+    public class GetPublicSectorOrgainsationQuery : IAsyncRequest<GetPublicSectorOrgainsationResponse>
+    {
+        public string SearchTerm { get; set; }
+        public int? PageNumber { get; set; }
+        public int? PageSize { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationResponse.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationResponse.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.EAS.Domain.Models.ReferenceData;
+
+namespace SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation
+{
+    public class GetPublicSectorOrgainsationResponse
+    {
+        public PagedResponse<PublicSectorOrganisation> Organisaions { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationValidator.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetPublicSectorOrganisation/GetPublicSectorOrgainsationValidator.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using SFA.DAS.EAS.Application.Validation;
+
+namespace SFA.DAS.EAS.Application.Queries.GetPublicSectorOrganisation
+{
+    public class GetPublicSectorOrgainsationValidator : IValidator<GetPublicSectorOrgainsationQuery>
+    {
+        public ValidationResult Validate(GetPublicSectorOrgainsationQuery item)
+        {
+            var validationResult = new ValidationResult();
+
+            if (item == null)
+            {
+                validationResult.ValidationDictionary.Add("Query", "Query should not be null");
+                return validationResult;
+            }
+
+            if (string.IsNullOrEmpty(item.SearchTerm))
+            {
+                validationResult.ValidationDictionary.Add("SearchTerm", "Search term has not been supplied");
+            }
+
+            return validationResult;
+        }
+
+        public Task<ValidationResult> ValidateAsync(GetPublicSectorOrgainsationQuery item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
@@ -361,6 +361,10 @@
     <Compile Include="Queries\GetProvider\GetProviderQueryHandler.cs" />
     <Compile Include="Queries\GetProvider\GetProviderQueryRequest.cs" />
     <Compile Include="Queries\GetProvider\GetProviderQueryResponse.cs" />
+    <Compile Include="Queries\GetPublicSectorOrganisation\GetPublicSectorOrgainsationHandler.cs" />
+    <Compile Include="Queries\GetPublicSectorOrganisation\GetPublicSectorOrgainsationQuery.cs" />
+    <Compile Include="Queries\GetPublicSectorOrganisation\GetPublicSectorOrgainsationResponse.cs" />
+    <Compile Include="Queries\GetPublicSectorOrganisation\GetPublicSectorOrgainsationValidator.cs" />
     <Compile Include="Queries\GetStandards\GetStandardsQueryHandler.cs" />
     <Compile Include="Queries\GetStandards\GetStandardsQueryRequest.cs" />
     <Compile Include="Queries\GetStandards\GetStandardsQueryResponse.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IReferenceDataService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IReferenceDataService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using SFA.DAS.EAS.Domain.Models.ReferenceData;
 
 namespace SFA.DAS.EAS.Domain.Interfaces
@@ -10,5 +6,19 @@ namespace SFA.DAS.EAS.Domain.Interfaces
     public interface IReferenceDataService
     {
         Task<Charity> GetCharity(int registrationNumber);
+
+        Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(string searchTerm);
+
+        Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(
+         string searchTerm,
+         int pageNumber);
+
+        Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(
+           string searchTerm,
+           int pageNumber,
+           int pageSize);
+
+        
+
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/ReferenceData/PagedResponse.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/ReferenceData/PagedResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace SFA.DAS.EAS.Domain.Models.ReferenceData
+{
+    public class PagedResponse<T>
+    {
+        public ICollection<T> Data { get; set; }
+        public int PageNumber { get; set; }
+        public int TotalPages { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Models\Levy\LevyDeclarationTransactionLine.cs" />
     <Compile Include="Models\Payments\PaymentTransactionLine.cs" />
     <Compile Include="Models\ReferenceData\Charity.cs" />
+    <Compile Include="Models\ReferenceData\PagedResponse.cs" />
     <Compile Include="Models\ReferenceData\PublicSectorOrganisation.cs" />
     <Compile Include="TransactionItemType.cs" />
     <Compile Include="Membership.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/ReferenceDataService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/ReferenceDataService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.ReferenceData;
@@ -9,6 +10,8 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 {
     public class ReferenceDataService : IReferenceDataService
     {
+        private const int DefaultPageSize = 100;
+
         private readonly IReferenceDataApiClient _client;
         private readonly IMapper _mapper;
 
@@ -25,21 +28,28 @@ namespace SFA.DAS.EAS.Infrastructure.Services
             return result;
         }
 
+        public Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(string searchTerm)
+        {
+            return SearchPublicSectorOrganisation(searchTerm, 1, DefaultPageSize);
+        }
 
+        public Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(string searchTerm, int pageNumber)
+        {
+            return SearchPublicSectorOrganisation(searchTerm, pageNumber, DefaultPageSize);
+        }
 
-        //public async Task<PagedApiResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(string searchTerm, int pageNumber, int pageSize)
-        //{
-        //    var dto = await _client.SearchPublicSectorOrganisation(searchTerm, pageNumber, pageSize);
+        public async Task<PagedResponse<PublicSectorOrganisation>> SearchPublicSectorOrganisation(string searchTerm, int pageNumber, int pageSize)
+        {
+            var dto = await _client.SearchPublicSectorOrganisation(searchTerm, pageNumber, pageSize);
+            
+            var orgainsations = dto.Data.Select(x => _mapper.Map<PublicSectorOrganisation>(x)).ToList();
 
-        //    var orgainsations = dto.Data.Select(x => new PublicSectorOrganisation { Name = x.Name }).ToList();
-
-        //    return new PagedApiResponse<PublicSectorOrganisation>
-        //    {
-        //        Data = orgainsations,
-        //        PageNumber = dto.PageNumber,
-        //        TotalPages = dto.TotalPages
-        //    };
-        //}
-
+            return new PagedResponse<PublicSectorOrganisation>
+            {
+                Data = orgainsations,
+                PageNumber = dto.PageNumber,
+                TotalPages = dto.TotalPages
+            };
+        }
     }
 }


### PR DESCRIPTION
Now there is a query in the application level that is fully wired up to the Reference Data Service
for getting public sector organisation via a search term.