### PR TITLE
Add organisation type for page tracking

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
@@ -147,7 +147,7 @@ namespace SFA.DAS.EAS.Web.Controllers
                 return RedirectToAction("Summary");
             }
             
-            TempData["employerAccountCreated"] = "true";
+            TempData["employerAccountCreated"] = enteredData.OrganisationType.ToString();
             TempData["successHeader"] = "Account Created";
             
             return RedirectToAction("Index", "EmployerTeam", new { response.Data.EmployerAgreement.HashedAccountId });

--- a/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
@@ -10,7 +10,7 @@
 
     if (TempData.ContainsKey("employerAccountCreated"))
     {
-        ViewBag.PageID = "page-employer-account-created";
+        ViewBag.PageID = $"page-employer-account-created-{TempData["employerAccountCreated"]}";
         TempData.Remove("employerAccountCreated");
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountControllerTests/WhenICreateAnAccount.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountControllerTests/WhenICreateAnAccount.cs
@@ -56,7 +56,8 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.EmployerAccountControllerTests
                 PayeReference = "123/ABC",
                 RefreshToken = "123",
                 AccessToken = "456",
-                EmpRefNotFound = true
+                EmpRefNotFound = true,
+                OrganisationType = OrganisationType.Charities
             };
 
             _orchestrator.Setup(x => x.GetCookieData(It.IsAny<HttpContextBase>()))
@@ -130,6 +131,20 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.EmployerAccountControllerTests
 
             //Assert
             Assert.IsTrue(_employerAccountController.TempData.ContainsKey("successHeader"));
+
+        }
+
+
+
+        [Test]
+        public async Task ThenIfTheAccountIsSucessfullyCreatedThenTheOrganisationTypeIsAddedToTempData()
+        {
+            //Act
+            await _employerAccountController.CreateAccount();
+
+            //Assert
+            Assert.IsTrue(_employerAccountController.TempData.ContainsKey("employerAccountCreated"));
+            Assert.AreEqual("Charities", _employerAccountController.TempData["employerAccountCreated"]);
 
         }
     }


### PR DESCRIPTION
Added the organisation type that has been selected during the
onboarding process to be used in the PageId tag that is shown once the
account is created