### PR TITLE
Incorrect legal entity in api uri

### DIFF
--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/EventPublisherServiceTests/WhenAPayeSchemeIsAdded.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/EventPublisherServiceTests/WhenAPayeSchemeIsAdded.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.EventPublisherServiceTes
         {
             var hashedAccountId = "ABC123";
             var payeSchemeRef = "ABC/123";
-            var expectedAccountResourceUri = $"api/accounts/{hashedAccountId}/payeschemes/{HttpUtility.UrlEncode(payeSchemeRef)}";
+            var expectedAccountResourceUri = $"api/accounts/{hashedAccountId}/payeschemes/ABC%252f123";
 
             await Publisher.PublishPayeSchemeAddedEvent(hashedAccountId, payeSchemeRef);
 

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/EventPublisherServiceTests/WhenAPayeSchemeIsRemoved.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/EventPublisherServiceTests/WhenAPayeSchemeIsRemoved.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.EventPublisherServiceTes
         {
             var hashedAccountId = "ABC123";
             var payeSchemeRef = "ABC/123";
-            var expectedAccountResourceUri = $"api/accounts/{hashedAccountId}/payeschemes/{HttpUtility.UrlEncode(payeSchemeRef)}";
+            var expectedAccountResourceUri = $"api/accounts/{hashedAccountId}/payeschemes/ABC%252f123";
 
             await Publisher.PublishPayeSchemeRemovedEvent(hashedAccountId, payeSchemeRef);
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/AccountRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/AccountRepository.cs
@@ -113,8 +113,8 @@ namespace SFA.DAS.EAS.Infrastructure.Data
                 parameters.Add("@signAgreement", signAgreement, DbType.Boolean);
                 parameters.Add("@signedDate", signedDate, DbType.DateTime);
                 parameters.Add("@signedById", signedById, DbType.Int64);
-                parameters.Add("@legalEntityId", signedById, DbType.Int64);
-                parameters.Add("@employerAgreementId", signedById, DbType.Int64);
+                parameters.Add("@legalEntityId", signedById, DbType.Int64, ParameterDirection.Output);
+                parameters.Add("@employerAgreementId", signedById, DbType.Int64, ParameterDirection.Output);
                 parameters.Add("@status", legalEntity.CompanyStatus, DbType.String);
                 parameters.Add("@source", legalEntity.Source, DbType.Int16);
                 parameters.Add("@publicSectorDataSource", legalEntity.PublicSectorDataSource, DbType.Int16);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/EventPublisher.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/EventPublisher.cs
@@ -47,6 +47,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
         private string CreatePayeSchemeUri(string hashedAccountId, string payeSchemeRef)
         {
+            // This is deliberately double encoded to minic the response the accounts web api returns when encoding the URI to json as part of the GetAccounts method.
             return CreateAccountUri(hashedAccountId) + $"/payeschemes/{HttpUtility.UrlEncode(HttpUtility.UrlEncode(payeSchemeRef))}";
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/EventPublisher.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/EventPublisher.cs
@@ -47,7 +47,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
         private string CreatePayeSchemeUri(string hashedAccountId, string payeSchemeRef)
         {
-            return CreateAccountUri(hashedAccountId) + $"/payeschemes/{HttpUtility.UrlEncode(payeSchemeRef)}";
+            return CreateAccountUri(hashedAccountId) + $"/payeschemes/{HttpUtility.UrlEncode(HttpUtility.UrlEncode(payeSchemeRef))}";
         }
 
         private string CreateAccountUri(string hashedAccountId)


### PR DESCRIPTION
Fixed issues with incorrect id being returned when adding a new legal entity and changed the URI on paye events so it is consistent with the URI returned from the accounts api.