### PR TITLE
Set ReferenceNumber to empty string

### DIFF
--- a/src/SFA.DAS.EAS.Web/Orchestrators/OrganisationOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/OrganisationOrchestrator.cs
@@ -422,7 +422,7 @@ namespace SFA.DAS.EAS.Web.Orchestrators
                         Name = model.OrganisationName,
                         Address = response.Address,
                         DateOfInception = model.OrganisationDateOfInception,
-                        ReferenceNumber = model.OrganisationReferenceNumber,
+                        ReferenceNumber = model.OrganisationReferenceNumber ?? string.Empty,
                         Type = model.OrganisationType,
                         PublicSectorDataSource = model.PublicSectorDataSource,
                         Status = model.OrganisationStatus,

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/OrganisationOrchestratorTests/WhenIAddAnOrganisationAddress.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/OrganisationOrchestratorTests/WhenIAddAnOrganisationAddress.cs
@@ -88,5 +88,19 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.OrganisationOrchestratorTests
             //Assert
             Assert.AreEqual(HttpStatusCode.BadRequest, result.Status);
         }
+
+
+        [Test]
+        public void ThenTheCodeIsDefaultedToEmptyStringIfNull()
+        {
+            //Arrange
+            _model.OrganisationReferenceNumber = null;
+
+            //Act
+            var actual = _orchestrator.AddOrganisationAddress(_model);
+
+            //Assert
+            Assert.AreEqual("",actual.Data.ReferenceNumber);
+        }
     }
 }


### PR DESCRIPTION
Change made so that the company reference number is set to string.empty
instead of null when there is no value for it.