### PR TITLE
Add created date to LevyDeclaration

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/CreateDeclaration.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/CreateDeclaration.sql
@@ -6,7 +6,8 @@
 	@AccountId BIGINT,
 	@LevyAllowanceForYear DECIMAL(18, 4),
 	@PayrollYear NVARCHAR(10),
-	@PayrollMonth TINYINT
+	@PayrollMonth TINYINT,
+	@CreatedDate DATETIME
 AS
 	
 
@@ -19,7 +20,8 @@ INSERT INTO [employer_financial].[LevyDeclaration]
 		AccountId,
 		LevyAllowanceForYear,
 		PayrollYear,
-		PayrollMonth
+		PayrollMonth,
+		CreatedDate
 	) 
 VALUES 
 	(
@@ -30,5 +32,6 @@ VALUES
 		@AccountId,
 		@LevyAllowanceForYear,
 		@PayrollYear,
-		@PayrollMonth
+		@PayrollMonth,
+		@CreatedDate
 	);

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
@@ -35,7 +35,7 @@ select mainUpdate.* from
 	(
 	select 
 			x.AccountId,
-			GetDate() as DateCreated,
+			y.CreatedDate as DateCreated,
 			x.SubmissionId as SubmissionId,
 			x.SubmissionDate as TransactionDate,
 			1 as TransactionType,

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
@@ -8,5 +8,6 @@
     [SubmissionDate] DATETIME NULL, 
     [SubmissionId] BIGINT NOT NULL DEFAULT 0,
 	[PayrollYear] NVARCHAR(10) NULL,
-	[PayrollMonth] TINYINT NULL
+	[PayrollMonth] TINYINT NULL,
+	[CreatedDate] DATETIME NOT NULL
 )

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Views/GetLevyDeclarations.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Views/GetLevyDeclarations.sql
@@ -18,7 +18,8 @@ SELECT
 		x.submissionDate 
 	when 
 		ld.SubmissionDate then 1 
-	else 0 end as LastSubmission
+	else 0 end as LastSubmission,
+	ld.CreatedDate
 FROM [employer_financial].[LevyDeclaration] ld
 inner join
 (

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/DasLevyRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/DasLevyRepository.cs
@@ -58,6 +58,7 @@ namespace SFA.DAS.EAS.Infrastructure.Data
                 parameters.Add("@PayrollMonth", dasDeclaration.PayrollMonth, DbType.Int16);
                 parameters.Add("@SubmissionDate", dasDeclaration.Date, DbType.DateTime);
                 parameters.Add("@SubmissionId", dasDeclaration.Id, DbType.String);
+                parameters.Add("@CreatedDate", DateTime.UtcNow, DbType.DateTime);
                 
                 return await c.ExecuteAsync(
                     sql: "[employer_financial].[CreateDeclaration]",


### PR DESCRIPTION
Added the createddate column to the LevyDeclaration column so we can
record when data has been processed and added to our system from HMRC.
This is then used on the transaction line table instead of GetDate