### PR TITLE
Handle the session expired flow for the Create Account journey.

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerAccountController.cs
@@ -130,6 +130,13 @@ namespace SFA.DAS.EAS.Web.Controllers
             return View();
         }
 
+        [HttpGet]
+        [Route("create")]
+        public ActionResult Create()
+        {
+            return RedirectToAction("Summary");
+        }
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         [Route("create")]


### PR DESCRIPTION
When a user sits on the create account summary screen and her session expires before she hits confirm a login flow is triggered with a redirect of /account/create however the action was intended to be a POST but EmployerUsers does a redirect which is a GET yielding a page not found to the user... this redirects back to the Summary screen where the user can pick up the journey again.