### PR TITLE
Added default of 1 to EF when there is none

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Views/GetLevyDeclarations.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Views/GetLevyDeclarations.sql
@@ -10,7 +10,7 @@ SELECT
 	ld.SubmissionDate AS SubmissionDate,
 	ld.SubmissionId AS SubmissionId,
 	ld.LevyDueYTD AS LevyDueYTD,
-	t.Amount AS EnglishFraction,
+	isnull(t.Amount,1) AS EnglishFraction,
 	w.amount as TopUpPercentage,
 	ld.PayrollYear as PayrollYear,
 	ld.PayrollMonth as PayrollMonth,


### PR DESCRIPTION
When there is no EF but a declaration this was causing errors when creating the transaction line value.