### PR TITLE
Use empref from command instead of hmrc response

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/UpdateEnglishFractions/UpdateEnglishFractionsCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/UpdateEnglishFractions/UpdateEnglishFractionsCommandHandler.cs
@@ -88,7 +88,7 @@ namespace SFA.DAS.EAS.Application.Commands.UpdateEnglishFractions
 
             foreach (var englishFraction in newFraction)
             {
-                await _englishFractionRepository.CreateEmployerFraction(englishFraction, englishFraction.EmpRef);
+                await _englishFractionRepository.CreateEmployerFraction(englishFraction, message.EmployerReference);
             }
             
         }


### PR DESCRIPTION
Change made so that the empref we use to store information in the
database is taken from the command, rather than the response from HMRC.
This is due to formatting problems with this information when it is
returned from the API