### PR TITLE
Aml 1141 - Transaction Date should be date added not submitted

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetTransactionDetail_ByDateRange.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetTransactionDetail_ByDateRange.sql
@@ -20,7 +20,8 @@ select
     tl.Amount as LineAmount,
     tl.TransactionType,
 	null as UkPrn,
-	null as PeriodEnd
+	null as PeriodEnd,
+	DateCreated
 from [employer_financial].TransactionLine tl
 inner join [employer_financial].LevyDeclarationTopup ldt on ldt.SubmissionId = tl.SubmissionId
 OUTER APPLY
@@ -31,8 +32,8 @@ OUTER APPLY
 		AND ef.[DateCalculated] <= tl.TransactionDate
 	ORDER BY [DateCalculated] DESC
 ) t
-where    tl.TransactionDate >= @fromDate AND 
-        tl.TransactionDate <= @toDate AND 
+where    tl.DateCreated >= @fromDate AND 
+        tl.DateCreated <= @toDate AND 
         tl.AccountId = @accountId
 
 union all
@@ -53,10 +54,11 @@ select
     (p.Amount) as LineAmount,
     tl.TransactionType,
 	p.Ukprn as UkPrn,
-	p.PeriodEnd as PeriodEnd  
+	p.PeriodEnd as PeriodEnd,
+	DateCreated
 from [employer_financial].TransactionLine tl
 inner join [employer_financial].Payment p on p.PeriodEnd = tl.PeriodEnd and p.AccountId = tl.AccountId
 inner join [employer_financial].PaymentMetaData meta on p.PaymentMetaDataId = meta.Id
-where   tl.TransactionDate >= @fromDate AND 
-        tl.TransactionDate <= @toDate AND 
+where   tl.DateCreated >= @fromDate AND 
+        tl.DateCreated <= @toDate AND 
         tl.AccountId = @accountId

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetTransactionLines_ByAccountId.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetTransactionLines_ByAccountId.sql
@@ -3,20 +3,21 @@
 AS
 select 
 	main.*
-	,SUM(Amount) OVER(ORDER BY TransactionDate asc 
+	,SUM(Amount) OVER(ORDER BY DateCreated asc 
 		RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) 
 	     AS Balance
 from
 (
 	SELECT 
 	   [AccountId]
-      ,[TransactionDate]
+      ,Max([TransactionDate]) as TransactionDate
       ,MAX([TransactionType]) as TransactionType
       ,Sum(Amount) as Amount
 	  ,UkPrn
+	  ,DateCreated
   FROM [employer_financial].[TransactionLine]
   WHERE AccountId = @accountId
-  GROUP BY TransactionDate ,AccountId, UKPRN
+  GROUP BY DateCreated ,AccountId, UKPRN
   
 ) as main
 order by TransactionDate desc

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
@@ -48,7 +48,7 @@ select mainUpdate.* from
 	(
 	select 
 			x.AccountId,
-			y.CreatedDate as DateCreated,
+			DATEFROMPARTS(DatePart(yyyy,y.CreatedDate),DatePart(MM,y.CreatedDate),DATEPART(dd,y.CreatedDate)) as DateCreated,
 			x.SubmissionId as SubmissionId,
 			x.SubmissionDate as TransactionDate,
 			1 as TransactionType,
@@ -72,7 +72,7 @@ select mainUpdate.* from
 	union all	
 		select 
 			x.AccountId,
-			x.CreatedDate as DateCreated,
+			DATEFROMPARTS(DatePart(yyyy,x.CreatedDate),DatePart(MM,x.CreatedDate),DATEPART(dd,x.CreatedDate)) as DateCreated,
 			x.SubmissionId as SubmissionId,
 			x.SubmissionDate as TransactionDate,
 			1 as TransactionType,

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
@@ -9,7 +9,7 @@ INSERT INTO [employer_financial].LevyDeclarationTopup
 
 	select 
 		x.AccountId,
-		GetDate() as DateAdded,
+		DATEFROMPARTS(DatePart(yyyy,GETDATE()),DatePart(MM,GETDATE()),DATEPART(dd,GETDATE())) as DateAdded,
 		x.SubmissionId,
 		x.SubmissionDate,
 		case y.PayrollMonth when 1 then  (y.LevyDueYTD* isnull(y.EnglishFraction,0))* isnull(y.TopUpPercentage,0) 
@@ -24,7 +24,7 @@ INSERT INTO [employer_financial].LevyDeclarationTopup
 	union all
 	select
 		x.AccountId,
-		GetDate() as DateAdded,
+		DATEFROMPARTS(DatePart(yyyy,GETDATE()),DatePart(MM,GETDATE()),DATEPART(dd,GETDATE())) as DateAdded,
 		x.SubmissionId,
 		x.SubmissionDate,
 		((x.EndOfYearAdjustmentAmount * isnull(x.EnglishFraction,0))* isnull(x.TopUpPercentage,0) * -1) as Amount

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessPaymentDataTransactions.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessPaymentDataTransactions.sql
@@ -8,7 +8,7 @@ select mainUpdate.* from
 	(
 	select 
 			x.AccountId as AccountId,
-			GETDATE() as DateCreated,
+			DATEFROMPARTS(DatePart(yyyy,GETDATE()),DatePart(MM,GETDATE()),DATEPART(dd,GETDATE())) as DateAdded,
 			null as submissionId,
 			Max(pe.CompletionDateTime) as TransactionDate,
 			3 as TransactionType,

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcDateServiceTests/WhenICompareTheSubmissionDateToPayrolDate.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcDateServiceTests/WhenICompareTheSubmissionDateToPayrolDate.cs
@@ -59,7 +59,8 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HmrcDateServiceTests
 
         [TestCase("2016-01-30", false)]
         [TestCase("2017-03-31", false)]
-        [TestCase("2017-04-01", true)]
+        [TestCase("2017-04-01", false)]
+        [TestCase("2017-04-22", true)]
         [TestCase("2018-05-30", true)]
         public void ThenIfTheSubmissionDateIsGreaterThanThePayrollYearThenTrueIsReturned(string submissionDate, bool expectedResult)
         {

--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/Index_DEC.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/Index_DEC.cshtml
@@ -52,11 +52,11 @@
                 <tbody>
                     @foreach (var aggregationLine in Model.Data.Model.Data.TransactionLines)
                     {
-                        var fromDate = aggregationLine.TransactionDate;
-                        var toDate = aggregationLine.TransactionDate;
+                        var fromDate = aggregationLine.DateCreated;
+                        var toDate = aggregationLine.DateCreated.AddHours(23);
                         <tr>
                             <td>
-                                <span class="no-wrap">@{var date = aggregationLine.TransactionDate.ToGdsFormat();} @date </span>
+                                <span class="no-wrap">@{var date = aggregationLine.DateCreated.ToGdsFormat();} @date </span>
                             </td>
                             <td class="mobile-hide-cell">
                                 <span class="description">

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/Transaction/TransactionLine.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/Transaction/TransactionLine.cs
@@ -9,6 +9,7 @@ namespace SFA.DAS.EAS.Domain.Models.Transaction
         public string Description { get; set; }
         public TransactionItemType TransactionType { get; set; }
         public DateTime TransactionDate { get; set; }
+        public DateTime DateCreated { get; set; }
         public decimal Amount { get; set; }
         public decimal Balance { get; set; }
         public List<TransactionLine> SubTransactions { get; set; }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/UserRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/UserRepository.cs
@@ -121,7 +121,7 @@ namespace SFA.DAS.EAS.Infrastructure.Data
                 var parameters = new DynamicParameters();
 
                 return await c.QueryAsync<User>(
-                    sql: "SELECT Id, CONVERT(varchar(64), PireanKey) as UserRef, Email, FirstName, LastName FROM [employer_account].[User];",
+                    sql: "SELECT Id, CONVERT(varchar(64), UserRef) as UserRef, Email, FirstName, LastName FROM [employer_account].[User];",
                     param: parameters,
                     commandType: CommandType.Text);
             });

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HmrcDateService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HmrcDateService.cs
@@ -22,6 +22,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
             DateTime endDate;
             GetDateRange(payrollYear, out endDate);
+            endDate = endDate.AddDays(21);
 
             return submissionDate >= endDate;
         }


### PR DESCRIPTION
The transaction date that is shown on the balance page should be the date that the levy was added to the account, not the date it was submitted.