### PR TITLE
Aml 1171 override levy flag

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/SFA.DAS.EAS.Employer_Financial.Database.sqlproj
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/SFA.DAS.EAS.Employer_Financial.Database.sqlproj
@@ -97,6 +97,7 @@
     <Build Include="Tables\EnglishFractionCalculationDate.sql" />
     <Build Include="StoredProcedures\GetLevyDeclaration_ByEmpRefPayrollMonthPayrollYear.sql" />
     <Build Include="StoredProcedures\GetLevyDeclarations_ByAccountPayrollMonthPayrollYear.sql" />
+    <Build Include="Tables\LevyOverride.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="SeedData\SeedData.sql" />

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAccountBalance_ByAccountIds.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAccountBalance_ByAccountIds.sql
@@ -10,10 +10,8 @@ AS
 	inner join 
 	(	select 
 			case when SUM(LevyDueYTD) > 0 then 1
-			else
-				case when MAX(t.IsLevyPayer) is not null 
-				then MAX(t.IsLevyPayer) 
-				else 0 end end
+			else ISNULL(MAX(t.IsLevyPayer),0)
+			end
 			as IsLevyPayer, 
 			AccountId 
 		from employer_financial.LevyDeclaration ld

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyOverride.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyOverride.sql
@@ -1,0 +1,8 @@
+﻿CREATE TABLE [employer_financial].[LevyOverride]
+(
+	[Id] BIGINT NOT NULL PRIMARY KEY IDENTITY, 
+	[AccountId] BIGINT NOT NULL,
+	[IsLevyPayer] TINYINT NOT NULL DEFAULT 0,
+	[DateAdded] DATETIME NOT NULL,
+	[ChangedBy] VARCHAR(500) NOT NULL
+)


### PR DESCRIPTION
Idea of this table is to be manually inserted into for a known account id. 

The following can be used:

```
insert into [employer_financial].LevyOverride
(accountid, islevypayer,dateadded,changedby)
values
(1,1,GETDATE(),'Test User')
```
This will then allow the flag to be overridden to determine whether or not an Account is a levy payer

@MichaelYoung1981 just tagging you so you are aware of this change we discussed yesterday.
