### PR TITLE
Change to show no transactions message

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/Index_DEC.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/Index_DEC.cshtml
@@ -62,7 +62,7 @@
 <div class="grid-row">
     <div class="column-full">
 
-        @if (Model.Data.Model.Data.TransactionLines.Count == 0)
+        @if (Model.Data.Model.Data.TransactionLines.All(c => c.TransactionType == TransactionItemType.Unknown))
         {
             <p class="panel panel-info">
                 @if (Model.Data.IsLatestMonth)
@@ -75,7 +75,7 @@
                 }
             </p>
         }
-        else if(Model.Data.Model.Data.TransactionLines.Count != 0)
+        else if(Model.Data.Model.Data.TransactionLines.Count(c => c.TransactionType == TransactionItemType.Unknown) != 0)
         {
             <table>
                 <thead>


### PR DESCRIPTION
Currently when we have no transactions a line is added as it is adding
the transaction type of unknown, this has been changed so that it will
only be levy and payments