### PR TITLE
AML-1226 Change logic for IsLevyPayer

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAccountBalance_ByAccountIds.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAccountBalance_ByAccountIds.sql
@@ -1,38 +1,42 @@
 ﻿CREATE PROCEDURE [employer_financial].[GetAccountBalance_ByAccountIds]
 	@accountIds [employer_financial].[AccountIds] Readonly
 AS
-	select 
-		tl.AccountId,
-		Sum(Amount) Balance ,
-		MAX(dervx.IsLevyPayer) IsLevyPayer
-	from 
-		[employer_financial].TransactionLine tl
-	inner join 
-	(	select 
-			case when SUM(LevyDueYTD) > 0 then 1
-			else ISNULL(MAX(t.IsLevyPayer),0)
-			end
-			as IsLevyPayer, 
-			AccountId 
-		from employer_financial.LevyDeclaration ld
-			OUTER APPLY
-			(
-				SELECT TOP 1 IsLevyPayer
-				FROM [employer_financial].LevyOverride lo
-				WHERE lo.AccountId = ld.AccountId 
-				ORDER BY [DateAdded] DESC
-			) t
-		group by accountid
-	) dervx on dervx.AccountId = tl.AccountId
-	inner join 
-		@accountIds acc on acc.AccountId = tl.AccountId
-	where tl.TransactionType in (1,2,3)
-	Group by tl.AccountId
-union
-	select 
-		accountid,
-		0 as Balance,
-		IsLevyPayer
-	from
-		[employer_financial].levyOverride
+	
+	SELECT
+		acc.AccountId,
+		isnull(bal.Balance,0) as Balance,
+		CASE
+			WHEN IsLevyPayer IS NOT NULL THEN IsLevyPayer
+			WHEN HasDeclaredLevy = 1 AND AmountLevyDeclared > 0 THEN 1
+			WHEN HasDeclaredLevy = 1 AND AmountLevyDeclared = 0 THEN 1 -- this needs to go back to 0 after month 1
+			ELSE 1
+		END IsLevyPayer
+	FROM @accountIds acc
+	OUTER APPLY
+	(
+		SELECT TOP 1 IsLevyPayer
+		FROM [employer_financial].LevyOverride lo
+		WHERE lo.AccountId = acc.AccountId 
+		ORDER BY [DateAdded] DESC
+	) t
+	OUTER APPLY
+	(
+		SELECT 
+			CASE
+				WHEN COUNT(1) > 0 THEN 1
+				ELSE 0
+			END HasDeclaredLevy,
+		SUM(LevyDueYTD) AmountLevyDeclared
+		FROM employer_financial.LevyDeclaration ld
+		WHERE ld.AccountId = acc.AccountId
+	) x
+	LEFT JOIN
+	(
+		SELECT
+			AccountId,
+			SUM(Amount) Balance
+		FROM employer_financial.TransactionLine
+		GROUP BY AccountId
+	) bal
+		ON acc.AccountId = bal.AccountId
 


### PR DESCRIPTION
Changed the logic for the IsLevyPayer flag to stop duplicates from
occurring when we have overridden a account that has declarations for it