### PR TITLE
AML-1241 Change to EF default value when getting LineDetail

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetLevyDetail_ByAccountIdAndDateRange.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetLevyDetail_ByAccountIdAndDateRange.sql
@@ -7,7 +7,7 @@ AS
 select 
     tl.AccountId,
     tl.LevyDeclared as Amount,
-    t.Amount as EnglishFraction,
+    isnull(t.Amount,1) as EnglishFraction,
     ldt.Amount as TopUp,
     tl.EmpRef,
 	null as CourseName,


### PR DESCRIPTION
Changed the default EF value to be 1 to match the default that we apply
in the calculation of 100%. This is to correct a display bug of showing
0% when it should be 100%