### PR TITLE
AML 1287 & 1291

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccount/RenameAccount.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccount/RenameAccount.cshtml
@@ -18,7 +18,7 @@
             <div class="form-group">
                 <dl>
                     <dt class="form-label-bold">Current name</dt>
-                    <dd class="force-word-wrap">@Model.Data.CurrentName</dd>
+                    <dd>@Model.Data.CurrentName</dd>
                 </dl>
             </div>
             <div class="form-group @(!string.IsNullOrEmpty(Model.Data.NewNameError) ? "error" : "")">

--- a/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
@@ -4,7 +4,7 @@
 @model OrchestratorResponse<SFA.DAS.EAS.Web.ViewModels.AccountDashboardViewModel>
 
 @{
-    ViewBag.Title = Model.Data.Account.Name;
+    ViewBag.Title = "Home";
     ViewBag.Section = "home";
     ViewBag.PageID = "page-company-homepage";
 


### PR DESCRIPTION
- Fixed word wrapping on the rename account view
- Changed the page title of the dashboard to 'Home' rather than using org name