### PR TITLE
Change cache to 30 mins from 1 day

### DIFF
--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcServiceTests/WhenICallHmrcServiceForLastEnglishFractionUpdateDate.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcServiceTests/WhenICallHmrcServiceForLastEnglishFractionUpdateDate.cs
@@ -85,7 +85,7 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HmrcServiceTests
 
             //Assert
             _httpClientWrapper.Verify(x => x.Get<DateTime>(ExpectedAccessCode, expectedApiUrl), Times.Once);
-            _cacheProvider.Verify(x => x.Set("HmrcFractionLastCalculatedDate", It.IsAny<DateTime>(), It.Is<TimeSpan>(c => c.Days.Equals(1))));
+            _cacheProvider.Verify(x => x.Set("HmrcFractionLastCalculatedDate", It.IsAny<DateTime>(), It.Is<TimeSpan>(c => c.Minutes.Equals(30))));
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HmrcService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HmrcService.cs
@@ -163,7 +163,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
                     if (hmrcLatestUpdateDate != null)
                     {
-                        _cacheProvider.Set("HmrcFractionLastCalculatedDate", hmrcLatestUpdateDate.Value,new TimeSpan(1,0,0,0));
+                        _cacheProvider.Set("HmrcFractionLastCalculatedDate", hmrcLatestUpdateDate.Value,new TimeSpan(0,0,30,0));
                     }
 
                     return hmrcLatestUpdateDate.Value;


### PR DESCRIPTION
Changed the cache for the fraction last calc date to be 30 minutes
instead of a day. Currently it is not expiring.