### PR TITLE
AML-1747 - Encode search term for filter

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/SearchOrganisation/SearchForOrganisationResults.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/SearchOrganisation/SearchForOrganisationResults.cshtml
@@ -33,7 +33,7 @@
 <div class="grid-row search-results">
     <aside>
         <h2 class="heading-medium">Filter results</h2>
-        <form action="@Url.Action("SearchForOrganisationResults")?searchTerm=@Model.Data.SearchTerm" method="POST">
+        <form action="@Url.Action("SearchForOrganisationResults")?searchTerm=@(HttpUtility.UrlEncode(Model.Data.SearchTerm))" method="POST">
             <div class="filter">
                 <fieldset>
                     <legend class="vh">Filter by organisation type</legend>


### PR DESCRIPTION
The filter was not urlencoding the search term meaning searches with
special characters being filter by type were not working correctly