### PR TITLE
[BUG] returning the correct employer agreement

### DIFF
--- a/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
@@ -91,8 +91,8 @@ namespace SFA.DAS.EAS.Api.Orchestrators
         public async Task<OrchestratorResponse<LegalEntityViewModel>> GetLegalEntity(string hashedAccountId, long legalEntityId)
         {
             _logger.Info($"Getting legal entity {legalEntityId} for account {hashedAccountId}");
-
-            var legalEntityResult = await _mediator.SendAsync(new GetLegalEntityByIdQuery { Id = legalEntityId });
+            var accountId = _hashingService.DecodeValue(hashedAccountId);
+            var legalEntityResult = await _mediator.SendAsync(new GetLegalEntityByIdQuery { AccountId = accountId, Id = legalEntityId });
             if (legalEntityResult.LegalEntity == null)
             {
                 return new OrchestratorResponse<LegalEntityViewModel> { Data = null };

--- a/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
@@ -91,8 +91,7 @@ namespace SFA.DAS.EAS.Api.Orchestrators
         public async Task<OrchestratorResponse<LegalEntityViewModel>> GetLegalEntity(string hashedAccountId, long legalEntityId)
         {
             _logger.Info($"Getting legal entity {legalEntityId} for account {hashedAccountId}");
-            var accountId = _hashingService.DecodeValue(hashedAccountId);
-            var legalEntityResult = await _mediator.SendAsync(new GetLegalEntityByIdQuery { AccountId = accountId, Id = legalEntityId });
+            var legalEntityResult = await _mediator.SendAsync(new GetLegalEntityByIdQuery { HashedAccountId = hashedAccountId, Id = legalEntityId });
             if (legalEntityResult.LegalEntity == null)
             {
                 return new OrchestratorResponse<LegalEntityViewModel> { Data = null };

--- a/src/SFA.DAS.EAS.Employer_Account.Database/StoredProcedures/GetLegalEntity_ById.sql
+++ b/src/SFA.DAS.EAS.Employer_Account.Database/StoredProcedures/GetLegalEntity_ById.sql
@@ -1,4 +1,5 @@
 ﻿CREATE PROCEDURE employer_account.GetLegalEntity_ById
+	@AccountId BIGINT,
 	@Id BIGINT
 AS
 Select 
@@ -21,6 +22,7 @@ OUTER APPLY
 	SELECT TOP 1 *
 	FROM employer_account.EmployerAgreement ea
 	WHERE ea.LegalEntityId = le.Id
+	AND ea.AccountId = @AccountId
 	ORDER BY Id DESC
 ) lea
 WHERE le.Id = @Id

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIGetALegalEntity.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIGetALegalEntity.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
             _expectedLegalEntity = new LegalEntityView();
 
             _legalEntityRepository = new Mock<ILegalEntityRepository>();
-            _legalEntityRepository.Setup(x => x.GetLegalEntityById(It.IsAny<long>())).ReturnsAsync(_expectedLegalEntity);
+            _legalEntityRepository.Setup(x => x.GetLegalEntityById(It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(_expectedLegalEntity);
 
             Query = new GetLegalEntityByIdQuery
             {
@@ -46,7 +46,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
             await RequestHandler.Handle(Query);
 
             //Assert
-            _legalEntityRepository.Verify(x => x.GetLegalEntityById(Query.Id), Times.Once);
+            _legalEntityRepository.Verify(x => x.GetLegalEntityById(Query.AccountId, Query.Id), Times.Once);
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIGetALegalEntity.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIGetALegalEntity.cs
@@ -6,6 +6,7 @@ using SFA.DAS.EAS.Application.Queries.GetLegalEntityById;
 using SFA.DAS.EAS.Application.Validation;
 using SFA.DAS.EAS.Domain.Data;
 using SFA.DAS.EAS.Domain.Data.Entities.Account;
+using SFA.DAS.EAS.Domain.Interfaces;
 
 namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
 {
@@ -18,6 +19,8 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
 
         private LegalEntityView _expectedLegalEntity;
 
+        private Mock<IHashingService> _hashingService;
+
         [SetUp]
         public void Arrange()
         {
@@ -27,26 +30,28 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
 
             _legalEntityRepository = new Mock<ILegalEntityRepository>();
             _legalEntityRepository.Setup(x => x.GetLegalEntityById(It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(_expectedLegalEntity);
+            _hashingService = new Mock<IHashingService>();
 
             Query = new GetLegalEntityByIdQuery
             {
                 Id = 123
             };
 
-            RequestHandler = new GetLegalEntityByIdHandler(RequestValidator.Object,_legalEntityRepository.Object);
+            RequestHandler = new GetLegalEntityByIdHandler(RequestValidator.Object,_legalEntityRepository.Object, _hashingService.Object);
         }
 
         [Test]
         public override async Task ThenIfTheMessageIsValidTheRepositoryIsCalled()
         {
+            var accountId = 1882;
             //Arrange
             RequestValidator.Setup(x => x.Validate(It.IsAny<GetLegalEntityByIdQuery>())).Returns(new ValidationResult {ValidationDictionary = new Dictionary<string, string>()});
-
+            _hashingService.Setup(m => m.DecodeValue(Query.HashedAccountId)).Returns(accountId);
             //Act
             await RequestHandler.Handle(Query);
 
             //Assert
-            _legalEntityRepository.Verify(x => x.GetLegalEntityById(Query.AccountId, Query.Id), Times.Once);
+            _legalEntityRepository.Verify(x => x.GetLegalEntityById(accountId, Query.Id), Times.Once);
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIValidateTheQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIValidateTheQuery.cs
@@ -32,6 +32,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
             //Act
             var actual = _validator.Validate(new GetLegalEntityByIdQuery
             {
+                AccountId = 666,
                 Id = 123
             });
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIValidateTheQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetLegalEntityByIdTests/WhenIValidateTheQuery.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetLegalEntityByIdTests
             //Act
             var actual = _validator.Validate(new GetLegalEntityByIdQuery
             {
-                AccountId = 666,
+                HashedAccountId = "ABBA12",
                 Id = 123
             });
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdHandler.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
                 throw new InvalidRequestException(validationResult.ValidationDictionary);
             }
 
-            var legalEntity = await _legalEntityRepository.GetLegalEntityById(message.Id);
+            var legalEntity = await _legalEntityRepository.GetLegalEntityById(message.AccountId, message.Id);
 
             return new GetLegalEntityByIdResponse { LegalEntity = legalEntity};
         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdHandler.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using SFA.DAS.EAS.Application.Validation;
 using SFA.DAS.EAS.Domain.Data;
+using SFA.DAS.EAS.Domain.Interfaces;
 
 namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
 {
@@ -9,11 +10,16 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
     {
         private readonly IValidator<GetLegalEntityByIdQuery> _validator;
         private readonly ILegalEntityRepository _legalEntityRepository;
+        private readonly IHashingService _hashingService;
 
-        public GetLegalEntityByIdHandler(IValidator<GetLegalEntityByIdQuery> validator, ILegalEntityRepository legalEntityRepository)
+        public GetLegalEntityByIdHandler(
+            IValidator<GetLegalEntityByIdQuery> validator, 
+            ILegalEntityRepository legalEntityRepository,
+            IHashingService hashingService)
         {
             _validator = validator;
             _legalEntityRepository = legalEntityRepository;
+            _hashingService = hashingService;
         }
 
         public async Task<GetLegalEntityByIdResponse> Handle(GetLegalEntityByIdQuery message)
@@ -25,7 +31,8 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
                 throw new InvalidRequestException(validationResult.ValidationDictionary);
             }
 
-            var legalEntity = await _legalEntityRepository.GetLegalEntityById(message.AccountId, message.Id);
+            var accountId = _hashingService.DecodeValue(message.HashedAccountId);
+            var legalEntity = await _legalEntityRepository.GetLegalEntityById(accountId, message.Id);
 
             return new GetLegalEntityByIdResponse { LegalEntity = legalEntity};
         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdQuery.cs
@@ -4,7 +4,7 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
 {
     public class GetLegalEntityByIdQuery : IAsyncRequest<GetLegalEntityByIdResponse>
     {
-        public long AccountId { get; set; }
+        public string HashedAccountId { get; set; }
 
         public long Id { get; set; }
     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdQuery.cs
@@ -4,6 +4,8 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
 {
     public class GetLegalEntityByIdQuery : IAsyncRequest<GetLegalEntityByIdResponse>
     {
+        public long AccountId { get; set; }
+
         public long Id { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdValidator.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdValidator.cs
@@ -10,9 +10,9 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
         {
             var validationResult = new ValidationResult();
 
-            if (item.AccountId == 0)
+            if (string.IsNullOrEmpty(item.HashedAccountId))
             {
-                validationResult.AddError(nameof(item.AccountId), "AccountId has not been supplied");
+                validationResult.AddError(nameof(item.HashedAccountId), "HashedAccountId has not been supplied");
             }
 
             if (item.Id == 0)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdValidator.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetLegalEntityById/GetLegalEntityByIdValidator.cs
@@ -10,10 +10,16 @@ namespace SFA.DAS.EAS.Application.Queries.GetLegalEntityById
         {
             var validationResult = new ValidationResult();
 
+            if (item.AccountId == 0)
+            {
+                validationResult.AddError(nameof(item.AccountId), "AccountId has not been supplied");
+            }
+
             if (item.Id == 0)
             {
                 validationResult.AddError(nameof(item.Id), "LegalEntityId has not been supplied");
             }
+
             return validationResult;
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Data/ILegalEntityRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Data/ILegalEntityRepository.cs
@@ -5,6 +5,6 @@ namespace SFA.DAS.EAS.Domain.Data
 {
     public interface ILegalEntityRepository
     {
-        Task<LegalEntityView> GetLegalEntityById(long id);
+        Task<LegalEntityView> GetLegalEntityById(long accountId, long id);
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/LegalEntityRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/LegalEntityRepository.cs
@@ -16,11 +16,12 @@ namespace SFA.DAS.EAS.Infrastructure.Data
         {
         }
 
-        public async Task<LegalEntityView> GetLegalEntityById(long id)
+        public async Task<LegalEntityView> GetLegalEntityById(long accontId, long id)
         {
             var result = await WithConnection(async c =>
             {
                 var parameters = new DynamicParameters();
+                parameters.Add("@AccountId", accontId, DbType.Int64);
                 parameters.Add("@Id", id, DbType.Int64);
 
                 return await c.QueryAsync<LegalEntityView>(


### PR DESCRIPTION
Several employer agreements can have the same LegalEntityId and therefor there is a risk of picking up the wrong agreement.  
I added account-id condition to make sure we only get agreements for the account calling the API.

On AT:
```
SELECT TOP 15 *
FROM employer_account.EmployerAgreement ea
WHERE ea.LegalEntityId = 18434
ORDER BY Id DESC
```
/c