### PR TITLE
AML-1607 Wrong English Fraction

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/EnglishFraction.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/EnglishFraction.sql
@@ -10,10 +10,10 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 
---This script should update all the EF values only if the column has just been added, which is when all the values are null 
+--This script should update all the EF values only if the column has just been added, which is when the EF value is null
+--it will never be null normally because processing levey declarations fills it in
 
-if 0 = (select count(*) from employer_financial.TransactionLine
-where EnglishFraction is NULL)
+
 	UPDATE
 	tl
 	SET
@@ -24,3 +24,4 @@ where EnglishFraction is NULL)
 	ON tl.EmpRef = td.EmpRef
 	AND tl.AccountId = td.AccountId
 	AND tl.SubmissionId = td.SubmissionId
+	AND tl.EnglishFraction Is Null

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/ProcessDeclarationsTransactions.sql
@@ -49,15 +49,14 @@ select mainUpdate.* from
 			x.SubmissionId as SubmissionId,
 			x.SubmissionDate as TransactionDate,
 			1 as TransactionType,
-			x.EnglishFraction,
 			x.LevyDeclaredInMonth as LevyDeclared,
-			x.TotalAmount as Amount,
-			
+			x.TotalAmount as Amount,		
 			x.EmpRef as EmpRef,
 			null as PeriodEnd,
 			null as UkPrn,
 			0 as SfaCoInvestmentAmount,
-			0 as EmployerCoInvestmentAmount
+			0 as EmployerCoInvestmentAmount,
+			x.EnglishFraction
 		FROM 
 			[employer_financial].[GetLevyDeclarationAndTopUp] x
 		where
@@ -69,14 +68,14 @@ select mainUpdate.* from
 			x.SubmissionId as SubmissionId,
 			x.SubmissionDate as TransactionDate,
 			1 as TransactionType,
-			NULL AS EnglishFraction,
 			x.LevyDueYTD as LevyDeclared,
 			((x.endofyearadjustmentamount * ISNULL(x.EnglishFraction,0)) - ldt.amount) * -1 as Amount,
 			x.EmpRef as EmpRef,
 			null as PeriodEnd,
 			null as UkPrn,
 			0 as SfaCoInvestmentAmount,
-			0 as EmployerCoInvestmentAmount
+			0 as EmployerCoInvestmentAmount,
+			NULL AS EnglishFraction
 		FROM 
 			[employer_financial].[GetLevyDeclarationAndTopUp] x
 		inner join


### PR DESCRIPTION
Fix to db script and SP.
The ordering of the insert for the TransactionLine table was not correct.
A simplification to the 'one off' script that fills in the new EnglishFraction column.

All tested locally.