### PR TITLE
Removing the configuration for the Apprenticeship Programmes API

### DIFF
--- a/src/SFA.DAS.EAS.Web/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.EAS.Web/DependencyResolution/DefaultRegistry.cs
@@ -92,7 +92,6 @@ namespace SFA.DAS.EAS.Web.DependencyResolution
 
             For<ICache>().Use<InMemoryCache>(); //RedisCache
 
-            For<IApprenticeshipInfoServiceConfiguration>().Use(config.ApprenticeshipInfoService);
             For<IEmployerCommitmentApi>().Use<EmployerCommitmentApi>().Ctor<ICommitmentsApiClientConfiguration>().Is(config.CommitmentsApi);
             For<IApprenticeshipApi>().Use<ApprenticeshipApi>().Ctor<ICommitmentsApiClientConfiguration>().Is(config.CommitmentsApi);
             For<IValidationApi>().Use<ValidationApi>().Ctor<ICommitmentsApiClientConfiguration>().Is(config.CommitmentsApi);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/ApprenticeshipInfoServiceWrapper.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/ApprenticeshipInfoServiceWrapper.cs
@@ -20,23 +20,19 @@ namespace SFA.DAS.EAS.Application
         private const string FrameworksKey = "Frameworks";
 
         private readonly ICache _cache;
-        private readonly IApprenticeshipInfoServiceConfiguration _configuration;
 
-        public ApprenticeshipInfoServiceWrapper(ICache cache, IApprenticeshipInfoServiceConfiguration configuration)
+        public ApprenticeshipInfoServiceWrapper(ICache cache)
         {
             if (cache == null)
                 throw new ArgumentNullException(nameof(cache));
-            if (configuration == null)
-                throw new ArgumentNullException(nameof(configuration));
             _cache = cache;
-            _configuration = configuration;
         }
 
         public async Task<StandardsView> GetStandardsAsync(bool refreshCache = false)
         {
             if (!await _cache.ExistsAsync(StandardsKey) || refreshCache)
             {
-                var api = new StandardApiClient(_configuration.BaseUrl);
+                var api = new StandardApiClient();
 
                 var standards = api.FindAll().OrderBy(x => x.Title).ToList();
 
@@ -50,7 +46,7 @@ namespace SFA.DAS.EAS.Application
         {
             if (!await _cache.ExistsAsync(FrameworksKey) || refreshCache)
             {
-                var api = new FrameworkApiClient(_configuration.BaseUrl);
+                var api = new FrameworkApiClient();
 
                 var frameworks = api.FindAll().OrderBy(x => x.Title).ToList();
 
@@ -64,7 +60,7 @@ namespace SFA.DAS.EAS.Application
         {
             try
             {
-                var api = new Providers.Api.Client.ProviderApiClient(_configuration.BaseUrl);
+                var api = new Providers.Api.Client.ProviderApiClient();
                 var provider = api.Get(ukPrn);
                 return MapFrom(provider);
             }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Configuration/EmployerApprenticeshipsServiceConfiguration.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Configuration/EmployerApprenticeshipsServiceConfiguration.cs
@@ -18,12 +18,6 @@ namespace SFA.DAS.EAS.Domain.Configuration
         public EventsApiClientConfiguration EventsApi { get; set; }
         public string Hashstring { get; set; }
         public string AllowedHashstringCharacters { get; set; }
-        public ApprenticeshipInfoServiceConfiguration ApprenticeshipInfoService { get; set; }
 		public PostcodeAnywhereConfiguration PostcodeAnywhere { get; set; }
-    }
-    
-    public class ApprenticeshipInfoServiceConfiguration : IApprenticeshipInfoServiceConfiguration
-    {
-        public string BaseUrl { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IApprenticeshipInfoServiceConfiguration.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IApprenticeshipInfoServiceConfiguration.cs
@@ -1,7 +1,0 @@
-﻿namespace SFA.DAS.EAS.Domain.Interfaces
-{
-    public interface IApprenticeshipInfoServiceConfiguration
-    {
-        string BaseUrl { get; set; }
-    }
-}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
@@ -200,7 +200,6 @@
     <Compile Include="Extensions\EnumerableExtension.cs" />
     <Compile Include="Http\InternalServerErrorException.cs" />
     <Compile Include="Http\RequestTimeOutException.cs" />
-    <Compile Include="Interfaces\IApprenticeshipInfoServiceConfiguration.cs" />
     <Compile Include="Interfaces\IApprenticeshipInfoServiceWrapper.cs" />
     <Compile Include="Interfaces\IAzureAdAuthenticationService.cs" />
     <Compile Include="Interfaces\ICookieStorageService.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIViewTheHomePage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIViewTheHomePage.cs
@@ -85,10 +85,6 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.HomeControllerTests
             ConfigurationFactory.Current = new IdentityServerConfigurationFactory(
                 new EmployerApprenticeshipsServiceConfiguration
                 {
-                    ApprenticeshipInfoService = new ApprenticeshipInfoServiceConfiguration
-                    {
-                        BaseUrl="http://test.local"
-                    },
                     Identity = new IdentityServerConfiguration { BaseAddress = "http://test.local/identity" ,AccountActivationUrl = "/confirm"}
                 });
             _owinWrapper.Setup(x => x.GetClaimValue("sub")).Returns(ExpectedUserId);


### PR DESCRIPTION
If you don't use the site url it defaults to prod which is what we want

```c#        
protected ApiClientBase(string baseUri = null)
{
	_httpClient = new HttpClient { BaseAddress = new Uri(baseUri ?? "http://das-prd-apprenticeshipinfoservice.cloudapp.net") };
}
```

![](https://media.giphy.com/media/l0HlBlaojMdbZh3fG/giphy.gif)