### PR TITLE
Halt levy declaration process if HMRC call fails.

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
@@ -37,7 +37,7 @@ namespace SFA.DAS.EAS.Infrastructure.ExecutionPolicies
             {
                 _logger.Error(ex, $"Exceeded retry limit - {ex.Message}");
             }
-            return default(T);
+            throw ex;
         }
 
         private void OnRetryableFailure(Exception ex)


### PR DESCRIPTION
After retrying the call to get English Fraction data from HMRC 5 times the process swallows the exception and proceeds to get levy information which then uses the incorrect English Fraction amount. The solution to this is to halt the process whenever an exception occurs (after retrying 5 times). Ultimately this will dead letter the message so we will have to monitor the queues so we can resend the message.