### PR TITLE
Updated web error handler to no longer log http 404 exceptions

### DIFF
--- a/src/SFA.DAS.EAS.Web/App_Start/RouteConfig.cs
+++ b/src/SFA.DAS.EAS.Web/App_Start/RouteConfig.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.EAS.Web
             routes.MapRoute(
                 name: "CatchAll",
                 url: "{*path}",
-                defaults: new { controller = "Home", action = "CatchAll", path = UrlParameter.Optional }
+                defaults: new { controller = "Error", action = "NotFound" }
             );
         }
     }

--- a/src/SFA.DAS.EAS.Web/Controllers/ErrorController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/ErrorController.cs
@@ -38,6 +38,8 @@ namespace SFA.DAS.EAS.Web.Controllers
         public ActionResult NotFound()
         {
             Response.StatusCode = (int)HttpStatusCode.NotFound;
+            Response.TrySkipIisCustomErrors = true;
+
             return View();
         }
 

--- a/src/SFA.DAS.EAS.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/HomeController.cs
@@ -238,13 +238,6 @@ namespace SFA.DAS.EAS.Web.Controllers
             return View(model);
         }
 
-        [Route("catchAll")]
-        public ActionResult CatchAll(string path = null)
-        {
-            return RedirectToAction(ControllerConstants.NotFoundViewName, ControllerConstants.ErrorControllerName, new { path });
-        }
-
-
 #if DEBUG
         [Route("CreateLegalAgreement/{showSubFields}")]
         public ActionResult ShowLegalAgreement(bool showSubFields)

--- a/src/SFA.DAS.EAS.Web/Plumbing/Mvc/LogAndHandleErrorAttribute.cs
+++ b/src/SFA.DAS.EAS.Web/Plumbing/Mvc/LogAndHandleErrorAttribute.cs
@@ -7,12 +7,14 @@ namespace SFA.DAS.EAS.Web.Plumbing.Mvc
     public class LogAndHandleErrorAttribute : HandleErrorAttribute
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         public override void OnException(ExceptionContext filterContext)
         {
-            var error = filterContext.Exception;
-            Logger.Error(error, "Unhandled exception - " + error.Message);
-            var ai = new TelemetryClient();
-            ai.TrackException(filterContext.Exception);
+            var exception = filterContext.Exception;
+            var tc = new TelemetryClient();
+
+            Logger.Error(exception, "Unhandled exception - " + exception.Message);
+            tc.TrackException(exception);
 
             base.OnException(filterContext);
         }

--- a/src/SFA.DAS.EAS.Web/Web.Debug.config
+++ b/src/SFA.DAS.EAS.Web/Web.Debug.config
@@ -26,5 +26,6 @@
         <error statusCode="500" redirect="InternalError.htm"/>
       </customErrors>
     -->
+    <customErrors mode="Off" xdt:Transform="SetAttributes(mode)" />
   </system.web>
 </configuration>

--- a/src/SFA.DAS.EAS.Web/Web.Release.config
+++ b/src/SFA.DAS.EAS.Web/Web.Release.config
@@ -22,10 +22,7 @@
       Note that because there is only one customErrors section under the
       <system.web> node, there is no need to use the "xdt:Locator" attribute.
     -->
-      <customErrors redirectMode="ResponseRedirect" defaultRedirect="/error/" mode="On" xdt:Transform="Replace">
-        <error statusCode="404" redirect="/error/notfound" />
-      </customErrors>
-    
+    <customErrors mode="On" xdt:Transform="SetAttributes(mode)" />
   </system.web>
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd" autoReload="true" throwExceptions="true" xdt:Transform="RemoveAttributes(internalLogLevel,internalLogFile)">
     <rules>

--- a/src/SFA.DAS.EAS.Web/Web.config
+++ b/src/SFA.DAS.EAS.Web/Web.config
@@ -37,9 +37,7 @@
   -->
   <system.web>
     <compilation debug="true" targetFramework="4.6.2" />
-    <customErrors mode="Off" redirectMode="ResponseRedirect">
-      <error statusCode="404" redirect="/error/notfound" />
-    </customErrors>
+    <customErrors mode="RemoteOnly"></customErrors>
     <httpRuntime targetFramework="4.5" enableVersionHeader="false" />
     <httpCookies httpOnlyCookies="true" requireSSL="true" lockItem="true" />
     <httpModules>
@@ -145,8 +143,8 @@
     <httpErrors errorMode="Custom" existingResponse="Auto">
       <remove statusCode="404" subStatusCode="-1" />
       <remove statusCode="500" subStatusCode="-1" />
-      <error statusCode="404" path="/error/NotFound" responseMode="ExecuteURL" />
-      <error statusCode="500" path="/error/Index" responseMode="ExecuteURL" />
+      <error statusCode="404" path="/error/notfound" responseMode="ExecuteURL" />
+      <error statusCode="500" path="/error" responseMode="ExecuteURL" />
     </httpErrors>
     <rewrite>
       <rules>


### PR DESCRIPTION
* Missing files are handled by `system.webServer.httpErrors`.
* Paths that match a route pattern but not a controller are handled by `Application_Error`.
* Paths that don't match a route pattern are handled by `ErrorController.NotFound`