### PR TITLE
AML-1972 Moved activities exception logging higher up in the call chain

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetAccountActivitiesTests/WhenIGetAnAccountsActivities.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetAccountActivitiesTests/WhenIGetAnAccountsActivities.cs
@@ -7,14 +7,12 @@ using SFA.DAS.Activities;
 using SFA.DAS.Activities.Client;
 using SFA.DAS.EAS.Application.Queries.GetAccountActivities;
 using SFA.DAS.EAS.Application.Validation;
-using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountActivitiesTests
 {
     public class WhenIGetAnAccountsActivities : QueryBaseTest<GetAccountActivitiesQueryHandler, GetAccountActivitiesQuery, GetAccountActivitiesResponse>
     {
         private Mock<IActivitiesClient> _activitiesClient;
-        private Mock<ILog> _logger;
         public override GetAccountActivitiesQuery Query { get; set; }
         public override GetAccountActivitiesQueryHandler RequestHandler { get; set; }
         public override Mock<IValidator<GetAccountActivitiesQuery>> RequestValidator { get; set; }
@@ -25,7 +23,6 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountActivitiesTests
             base.SetUp();
 
             _activitiesClient = new Mock<IActivitiesClient>();
-            _logger = new Mock<ILog>();
 
             Query = new GetAccountActivitiesQuery
             {
@@ -41,7 +38,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountActivitiesTests
                 }
             };
 
-            RequestHandler = new GetAccountActivitiesQueryHandler(_activitiesClient.Object, _logger.Object, RequestValidator.Object);
+            RequestHandler = new GetAccountActivitiesQueryHandler(_activitiesClient.Object, RequestValidator.Object);
         }
 
         [Test]
@@ -76,22 +73,6 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountActivitiesTests
             //Assert
             Assert.IsNotNull(response?.Result);
             Assert.AreEqual(activitiesResult, response.Result);
-        }
-
-        [Test]
-        public async Task ThenIfTheMessageIsValidShouldReturnNoActivitiesFromClientAndLogErrorWhenClientCausesException()
-        {
-            //Arrange
-            _activitiesClient.Setup(x => x.GetActivities(It.IsAny<ActivitiesQuery>())).Throws<Exception>();
-
-            //Act
-            var response = await RequestHandler.Handle(Query);
-
-            //Assert
-            Assert.IsNotNull(response?.Result);
-            Assert.IsEmpty(response.Result.Activities);
-            Assert.AreEqual(response.Result.Total, 0);
-            _logger.Verify(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetAccountLatestActivitiesTests/WhenIGetAnAccountsLatestActivities.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetAccountLatestActivitiesTests/WhenIGetAnAccountsLatestActivities.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountLatestActivitiesTe
     public class WhenIGetAnAccountsLatestActivities : QueryBaseTest<GetAccountLatestActivitiesQueryHandler, GetAccountLatestActivitiesQuery, GetAccountLatestActivitiesResponse>
     {
         private Mock<IActivitiesClient> _activitiesClient;
-        private Mock<ILog> _logger;
         public override GetAccountLatestActivitiesQuery Query { get; set; }
         public override GetAccountLatestActivitiesQueryHandler RequestHandler { get; set; }
         public override Mock<IValidator<GetAccountLatestActivitiesQuery>> RequestValidator { get; set; }
@@ -23,14 +22,13 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountLatestActivitiesTe
             base.SetUp();
 
             _activitiesClient = new Mock<IActivitiesClient>();
-            _logger = new Mock<ILog>();
 
             Query = new GetAccountLatestActivitiesQuery
             {
                 AccountId = 2
             };
 
-            RequestHandler = new GetAccountLatestActivitiesQueryHandler(_activitiesClient.Object, _logger.Object, RequestValidator.Object);
+            RequestHandler = new GetAccountLatestActivitiesQueryHandler(_activitiesClient.Object, RequestValidator.Object);
         }
 
         [Test]
@@ -57,22 +55,6 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetAccountLatestActivitiesTe
             //Assert
             Assert.IsNotNull(response?.Result);
             Assert.AreEqual(latestActivitiesResult, response.Result);
-        }
-
-        [Test]
-        public async Task ThenIfTheMessageIsValidShouldReturnNoActivitiesFromClientAndLogErrorWhenClientCausesException()
-        {
-            //Arrange
-            _activitiesClient.Setup(x => x.GetLatestActivities(It.IsAny<long>())).Throws<Exception>();
-
-            //Act
-            var response = await RequestHandler.Handle(Query);
-
-            //Assert
-            Assert.IsNotNull(response?.Result);
-            Assert.IsEmpty(response.Result.Aggregates);
-            Assert.AreEqual(response.Result.Total, 0);
-            _logger.Verify(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetAccountActivities/GetAccountActivitiesQueryHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetAccountActivities/GetAccountActivitiesQueryHandler.cs
@@ -1,23 +1,19 @@
 ﻿using System;
 using System.Threading.Tasks;
 using MediatR;
-using SFA.DAS.Activities;
 using SFA.DAS.Activities.Client;
 using SFA.DAS.EAS.Application.Validation;
-using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Application.Queries.GetAccountActivities
 {
     public class GetAccountActivitiesQueryHandler : IAsyncRequestHandler<GetAccountActivitiesQuery, GetAccountActivitiesResponse>
     {
         private readonly IActivitiesClient _activitiesClient;
-        private readonly ILog _logger;
         private readonly IValidator<GetAccountActivitiesQuery> _validator;
 
-        public GetAccountActivitiesQueryHandler(IActivitiesClient activitiesClient, ILog logger, IValidator<GetAccountActivitiesQuery> validator)
+        public GetAccountActivitiesQueryHandler(IActivitiesClient activitiesClient, IValidator<GetAccountActivitiesQuery> validator)
         {
             _activitiesClient = activitiesClient;
-            _logger = logger;
             _validator = validator;
         }
 
@@ -25,37 +21,21 @@ namespace SFA.DAS.EAS.Application.Queries.GetAccountActivities
         {
             ValidateMessage(message);
 
-            try
+            var result = await _activitiesClient.GetActivities(new ActivitiesQuery
             {
-                var result = await _activitiesClient.GetActivities(new ActivitiesQuery
-                {
-                    AccountId = message.AccountId,
-                    Take = message.Take,
-                    From = message.From,
-                    To = message.To,
-                    Term = message.Term,
-                    Category = message.Category,
-                    Data = message.Data
-                });
+                AccountId = message.AccountId,
+                Take = message.Take,
+                From = message.From,
+                To = message.To,
+                Term = message.Term,
+                Category = message.Category,
+                Data = message.Data
+            });
 
-                return new GetAccountActivitiesResponse
-                {
-                    Result = result
-                };
-            }
-            catch (Exception ex)
+            return new GetAccountActivitiesResponse
             {
-                _logger.Error(ex, "Could not retrieve account activities successfully.");
-
-                return new GetAccountActivitiesResponse
-                {
-                    Result = new ActivitiesResult
-                    {
-                        Activities = new Activity[0],
-                        Total = 0
-                    }
-                };
-            }
+                Result = result
+            };
         }
 
         private void ValidateMessage(GetAccountActivitiesQuery message)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetAccountLatestActivities/GetAccountLatestActivitiesQueryHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetAccountLatestActivities/GetAccountLatestActivitiesQueryHandler.cs
@@ -1,22 +1,18 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.Activities.Client;
 using SFA.DAS.EAS.Application.Validation;
-using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Application.Queries.GetAccountLatestActivities
 {
     public class GetAccountLatestActivitiesQueryHandler : IAsyncRequestHandler<GetAccountLatestActivitiesQuery, GetAccountLatestActivitiesResponse>
     {
         private readonly IActivitiesClient _activitiesClient;
-        private readonly ILog _logger;
         private readonly IValidator<GetAccountLatestActivitiesQuery> _validator;
 
-        public GetAccountLatestActivitiesQueryHandler(IActivitiesClient activitiesClient, ILog logger, IValidator<GetAccountLatestActivitiesQuery> validator)
+        public GetAccountLatestActivitiesQueryHandler(IActivitiesClient activitiesClient, IValidator<GetAccountLatestActivitiesQuery> validator)
         {
             _activitiesClient = activitiesClient;
-            _logger = logger;
             _validator = validator;
         }
 
@@ -24,28 +20,12 @@ namespace SFA.DAS.EAS.Application.Queries.GetAccountLatestActivities
         {
             ValidateMessage(message);
 
-            try
-            {
-                var result = await _activitiesClient.GetLatestActivities(message.AccountId);
+            var result = await _activitiesClient.GetLatestActivities(message.AccountId);
 
-                return new GetAccountLatestActivitiesResponse
-                {
-                    Result = result
-                };
-            }
-            catch (Exception ex)
+            return new GetAccountLatestActivitiesResponse
             {
-                _logger.Error(ex, "Could not retrieve account latest activities successfully.");
-
-                return new GetAccountLatestActivitiesResponse
-                {
-                    Result = new AggregatedActivitiesResult
-                    {
-                        Aggregates = new AggregatedActivityResult[0],
-                        Total = 0
-                    }
-                };
-            }
+                Result = result
+            };
         }
 
         private void ValidateMessage(GetAccountLatestActivitiesQuery message)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenGettingAccount.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenGettingAccount.cs
@@ -17,6 +17,7 @@ using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.Account;
 using SFA.DAS.EAS.Domain.Models.AccountTeam;
 using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -108,7 +109,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 
             _currentDateTime = new Mock<ICurrentDateTime>();
 
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, _currentDateTime.Object);
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, _currentDateTime.Object, Mock.Of<ILog>());
         }
         
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIChangeATeamMemberRole.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIChangeATeamMemberRole.cs
@@ -11,6 +11,7 @@ using SFA.DAS.EAS.Application.Queries.GetAccountTeamMembers;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.UserProfile;
 using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -24,7 +25,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
         public void Arrange()
         {
             _mediator = new Mock<IMediator>();
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>());
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>(), Mock.Of<ILog>());
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetATeamMembersDetails.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetATeamMembersDetails.cs
@@ -9,6 +9,7 @@ using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.AccountTeam;
 using SFA.DAS.EAS.Domain.Models.UserProfile;
 using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -35,7 +36,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 
             _mediator = new Mock<IMediator>();
 
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>());
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>(), Mock.Of<ILog>());
 
             _mediator.Setup(x => x.SendAsync(It.IsAny<GetMemberRequest>()))
                 .ReturnsAsync(_teamMemberResponse);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetMyTeamMembers.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIGetMyTeamMembers.cs
@@ -7,6 +7,7 @@ using SFA.DAS.EAS.Application.Queries.GetAccountTeamMembers;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.AccountTeam;
 using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -26,7 +27,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
                             TeamMembers = new List<TeamMember> {new TeamMember()}
                         });
          
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>());
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>(), Mock.Of<ILog>());
         }
         
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIInviteATeamMember.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIInviteATeamMember.cs
@@ -13,6 +13,7 @@ using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.UserProfile;
 using SFA.DAS.EAS.Web.Orchestrators;
 using SFA.DAS.EAS.Web.ViewModels;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -25,7 +26,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
         public void Arrange()
         {
             _mediator = new Mock<IMediator>();
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>());
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>(), Mock.Of<ILog>());
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIRemoveATeamMember.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerTeamOrchestratorTests/WhenIRemoveATeamMember.cs
@@ -13,6 +13,7 @@ using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.AccountTeam;
 using SFA.DAS.EAS.Domain.Models.UserProfile;
 using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
 {
@@ -26,7 +27,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerTeamOrchestratorTests
         {
             _mediator = new Mock<IMediator>();
 
-            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>());
+            _orchestrator = new EmployerTeamOrchestrator(_mediator.Object, Mock.Of<ICurrentDateTime>(), Mock.Of<ILog>());
             
             _mediator.Setup(x => x.SendAsync(It.IsAny<GetAccountTeamMembersQuery>()))
                      .ReturnsAsync(new GetAccountTeamMembersResponse


### PR DESCRIPTION
Exceptions are being swallowed by orchestrators and not logged.