### PR TITLE
Aml 2039 improve bad request logging

### DIFF
--- a/src/SFA.DAS.EAS.Account.Api.UnitTests/SFA.DAS.EAS.Account.Api.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.Account.Api.UnitTests/SFA.DAS.EAS.Account.Api.UnitTests.csproj
@@ -73,8 +73,8 @@
     <Reference Include="SFA.DAS.HashingService, Version=1.0.0.43004, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.HashingService.1.0.0.43004\lib\net45\SFA.DAS.HashingService.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SFA.DAS.EAS.Account.Api.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.Account.Api.UnitTests/packages.config
@@ -12,5 +12,5 @@
   <package id="NLog" version="4.4.1" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="SFA.DAS.HashingService" version="1.0.0.43004" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.EAS.Api/SFA.DAS.EAS.Account.Api.csproj
+++ b/src/SFA.DAS.EAS.Api/SFA.DAS.EAS.Account.Api.csproj
@@ -199,8 +199,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.34273\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>

--- a/src/SFA.DAS.EAS.Api/packages.config
+++ b/src/SFA.DAS.EAS.Api/packages.config
@@ -60,7 +60,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net462" requireReinstallation="true" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.Host.WebJob/SFA.DAS.EAS.Host.WebJob.csproj
+++ b/src/SFA.DAS.EAS.Host.WebJob/SFA.DAS.EAS.Host.WebJob.csproj
@@ -60,10 +60,14 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -73,6 +77,9 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />

--- a/src/SFA.DAS.EAS.Host.WebJob/Web.config
+++ b/src/SFA.DAS.EAS.Host.WebJob/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
@@ -13,21 +13,28 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.6.2"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.6.2" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer></configuration>

--- a/src/SFA.DAS.EAS.Host.WebJob/packages.config
+++ b/src/SFA.DAS.EAS.Host.WebJob/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.12" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
   <package id="NLog" version="4.3.7" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
@@ -155,6 +155,9 @@
     <Compile Include="Mapping\PaymentMappingTests\WhenIMapAPaymentToPaymentDetails.cs" />
     <Compile Include="NoopExecutionPolicy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\HttpResponseLoggerTests\WhenIReceiveNoResponse.cs" />
+    <Compile Include="Services\HttpResponseLoggerTests\WhenIReceiveJsonResponse.cs" />
+    <Compile Include="Services\HttpResponseLoggerTests\WhenIReceiveAStringResponse.cs" />
     <Compile Include="Services\AuditServiceTests\WhenISendAnAuditMessage.cs" />
     <Compile Include="Services\CommitmentsServiceTests\WhenIRequestAccountCommitments.cs" />
     <Compile Include="Services\CompaniesHouseEmployerVerificationServiceTests\WhenIGetCompanyInformation.cs" />

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
@@ -109,8 +109,8 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.0.0.34401\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>
@@ -141,7 +141,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveAStringResponse.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveAStringResponse.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Infrastructure.Services;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HttpResponseLoggerTests
+{
+    public class WhenIReceiveAStringResponse
+    {
+        private Mock<ILog> _logger;
+        private HttpResponseLogger _httpResponseLogger;
+        private HttpResponseMessage _httpResponseMessage;
+
+        private const string TestContent = "Some test content";
+        private const HttpStatusCode TestStatusCode = HttpStatusCode.BadRequest;
+        private const string TestReason = "Some error summary";
+
+        [SetUp]
+        public void Arrange()
+        {
+            _logger = new Mock<ILog>();
+            _httpResponseLogger = new HttpResponseLogger();
+            _httpResponseMessage = new HttpResponseMessage(TestStatusCode) { Content = new StringContent(TestContent), ReasonPhrase = TestReason};
+        }
+
+        [Test]
+        public async Task ThenTheContentShouldBeLogged()
+        {
+            // Arrange
+            _logger.Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()));
+
+            // Act
+            await _httpResponseLogger.LogResponseAsync(_logger.Object, _httpResponseMessage);
+
+            // Assert
+            _logger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string,object>>()), Times.Once);
+        }
+
+        [TestCase("Content", TestContent)]
+        [TestCase("StatusCode", TestStatusCode)]
+        [TestCase("Reason", TestReason)]
+        public async Task ThenTheMessageShouldBeLogged(string expectedPropertyName, object expectedPropertyValue)
+        {
+            // Arrange
+            IDictionary<string, object> actualProperties = null;
+            _logger
+                .Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()))
+                .Callback<string, IDictionary<string, object>>((msg, properties) => actualProperties = properties);
+
+            // Act
+            await _httpResponseLogger.LogResponseAsync(_logger.Object, _httpResponseMessage);
+
+            // Assert
+            Assert.IsTrue(actualProperties.ContainsKey(expectedPropertyName), $"logger was not supplied property {expectedPropertyName}");
+            var actualPropertyValue = actualProperties[expectedPropertyName];
+            Assert.IsNotNull(actualPropertyValue, $"logger was supplied null for property {expectedPropertyName}");
+            Assert.AreEqual(expectedPropertyValue.ToString(), actualPropertyValue.ToString(), $"logger was supplied an unexpected value for property {expectedPropertyName}");
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveJsonResponse.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveJsonResponse.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Infrastructure.Services;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HttpResponseLoggerTests
+{
+    public class WhenIReceiveJsonResponse
+    {
+        private Mock<ILog> _logger;
+        private HttpResponseLogger _httpResponseLogger;
+        private HttpResponseMessage _httpResponseMessage;
+
+        public class TestClass
+        {
+            public string Field1 { get; set; }
+            public int Field2 { get; set; }
+        }
+
+        private readonly TestClass _testContent = new TestClass {Field1 = "Test", Field2 = 123};
+
+        [SetUp]
+        public void Arrange()
+        {
+            _logger = new Mock<ILog>();
+            _httpResponseLogger = new HttpResponseLogger();
+            _httpResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(_testContent)),
+                Headers =
+                {
+                    {"ContentType", "application/json"}
+                }
+            };
+        }
+
+        [Test]
+        public async Task ThenTheContentShouldBeLogged()
+        {
+            // Arrange
+            _logger.Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()));
+
+            // Act
+            await _httpResponseLogger.LogResponseAsync(_logger.Object, _httpResponseMessage);
+
+            // Assert
+            _logger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string,object>>()), Times.Once);
+        }
+
+        public async Task ThenTheJsonContentShouldBeLogged()
+        {
+            // Arrange
+            IDictionary<string, object> actualProperties = null;
+            _logger
+                .Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()))
+                .Callback<string, IDictionary<string, object>>((msg, properties) => actualProperties = properties);
+
+            // Act
+            await _httpResponseLogger.LogResponseAsync(_logger.Object, _httpResponseMessage);
+            var content = actualProperties["Content"].ToString();
+            var rehydratedClass = Newtonsoft.Json.JsonConvert.DeserializeObject<TestClass>(content);
+
+            // Assert
+            Assert.IsNotNull(rehydratedClass);
+            Assert.AreEqual(_testContent.Field1, rehydratedClass.Field1);
+            Assert.AreEqual(_testContent.Field2, rehydratedClass.Field2);
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveNoResponse.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HttpResponseLoggerTests/WhenIReceiveNoResponse.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Infrastructure.Services;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HttpResponseLoggerTests
+{
+    public class WhenIReceiveNoResponse
+    {
+        private Mock<ILog> _logger;
+        private HttpResponseLogger _httpResponseLogger;
+        private HttpResponseMessage _httpResponseMessage;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _logger = new Mock<ILog>();
+            _httpResponseLogger = new HttpResponseLogger();
+            _httpResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = null,
+                Headers =
+                {
+                    {"ContentType", "application/json"}
+                }
+            };
+        }
+
+        [Test]
+        public async Task ThenTheContentShouldNotBeLogged()
+        {
+            // Arrange
+            _logger.Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()));
+
+            // Act
+            await _httpResponseLogger.LogResponseAsync(_logger.Object, _httpResponseMessage);
+
+            // Assert
+            _logger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<Dictionary<string,object>>()), Times.Never);
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/packages.config
@@ -5,6 +5,8 @@
   <package id="Elasticsearch.Net" version="5.5.0" targetFramework="net462" />
   <package id="FluentAssertions" version="4.17.0" targetFramework="net45" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.16.0" targetFramework="net462" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
@@ -18,7 +20,7 @@
   <package id="SFA.DAS.Common.Domain" version="1.3.0.44308" targetFramework="net462" />
   <package id="SFA.DAS.CookieService" version="1.0.0.27423" targetFramework="net45" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="SFA.DAS.ReferenceData.Api.Client" version="1.0.0.33424" targetFramework="net45" />
   <package id="SFA.DAS.Tasks.Api.Client" version="1.7.0.49084" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests.csproj
+++ b/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests.csproj
@@ -98,8 +98,8 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.17615, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.17615\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.0.0.34401\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>
@@ -112,10 +112,16 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/packages.config
@@ -3,6 +3,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -21,7 +23,7 @@
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.36524" targetFramework="net462" />
   <package id="SFA.DAS.HashingService" version="1.0.0.43004" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.17615" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.LevyAccountUpdater.UnitTests/SFA.DAS.EAS.LevyAccountUpdater.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.LevyAccountUpdater.UnitTests/SFA.DAS.EAS.LevyAccountUpdater.UnitTests.csproj
@@ -58,11 +58,17 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.LevyAccountUpdater.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.LevyAccountUpdater.UnitTests/packages.config
@@ -2,10 +2,12 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Moq" version="4.5.23" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
   <package id="NLog" version="4.3.10" targetFramework="net462" />
   <package id="NUnit" version="3.5.0" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/SFA.DAS.EAS.LevyAccountUpdater.WebJob.csproj
+++ b/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/SFA.DAS.EAS.LevyAccountUpdater.WebJob.csproj
@@ -99,8 +99,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.34273\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
@@ -116,6 +116,9 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -123,6 +126,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/packages.config
+++ b/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Mediator" version="1.0.2123.0" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2" targetFramework="net462" />
@@ -19,7 +21,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net462" requireReinstallation="true" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests.csproj
@@ -64,8 +64,8 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.1.608.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
@@ -74,6 +74,12 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.PaymentProvider.Worker.UnitTests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NLog" version="4.3.7" targetFramework="net45" />
@@ -9,6 +11,6 @@
   <package id="SFA.DAS.Commitments.Api.Types" version="2.0.0.44695" targetFramework="net462" />
   <package id="SFA.DAS.Common.Domain" version="1.3.0.44308" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/src/SFA.DAS.EAS.PaymentProvider.Worker/SFA.DAS.EAS.PaymentProvider.Worker.csproj
+++ b/src/SFA.DAS.EAS.PaymentProvider.Worker/SFA.DAS.EAS.PaymentProvider.Worker.csproj
@@ -116,8 +116,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.34273\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
@@ -139,6 +139,10 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -147,6 +151,9 @@
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.PaymentProvider.Worker/packages.config
+++ b/src/SFA.DAS.EAS.PaymentProvider.Worker/packages.config
@@ -3,6 +3,8 @@
   <package id="Antlr" version="3.4.1.9004" targetFramework="net462" />
   <package id="AutoMapper" version="5.1.1" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -20,7 +22,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net462" requireReinstallation="true" />

--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests.csproj
@@ -58,8 +58,8 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.0.0.34401\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>
@@ -69,6 +69,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob.UnitTests/packages.config
@@ -2,11 +2,13 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NLog" version="4.3.10" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob/SFA.DAS.EAS.PaymentUpdater.WebJob.csproj
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob/SFA.DAS.EAS.PaymentUpdater.WebJob.csproj
@@ -103,8 +103,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.34273\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
@@ -125,11 +125,18 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob/packages.config
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="AutoMapper" version="5.1.1" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2" targetFramework="net462" />
@@ -18,7 +20,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net462" requireReinstallation="true" />

--- a/src/SFA.DAS.EAS.Transactions.AcceptanceTests/SFA.DAS.EAS.Transactions.AcceptanceTests.csproj
+++ b/src/SFA.DAS.EAS.Transactions.AcceptanceTests/SFA.DAS.EAS.Transactions.AcceptanceTests.csproj
@@ -125,8 +125,8 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.17615, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.17615\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.0.0.34401\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>
@@ -139,10 +139,16 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EAS.Transactions.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.EAS.Transactions.AcceptanceTests/packages.config
@@ -4,6 +4,8 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -25,7 +27,7 @@
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.36524" targetFramework="net462" />
   <package id="SFA.DAS.HashingService" version="1.0.0.43004" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.17615" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerAccounts.Events/SFA.DAS.EmployerAccounts.Events.csproj
+++ b/src/SFA.DAS.EmployerAccounts.Events/SFA.DAS.EmployerAccounts.Events.csproj
@@ -42,12 +42,17 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.17615, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.17615\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EmployerAccounts.Events/packages.config
+++ b/src/SFA.DAS.EmployerAccounts.Events/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
   <package id="NLog" version="4.3.7" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.17615" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IHttpResponseLogger.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IHttpResponseLogger.cs
@@ -1,0 +1,11 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EAS.Domain.Interfaces
+{
+    public interface IHttpResponseLogger
+    {
+        Task LogResponseAsync(ILog logger, HttpResponseMessage response);
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
@@ -130,9 +130,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.17615, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.17615\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Notifications.Api.Client, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Notifications.Api.Client.2.0.0.35919\lib\net45\SFA.DAS.Notifications.Api.Client.dll</HintPath>
@@ -169,11 +168,17 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Http\ServiceUnavailableException.cs" />
     <Compile Include="Http\TooManyRequestsException.cs" />
     <Compile Include="Interfaces\IHmrcDateService.cs" />
+    <Compile Include="Interfaces\IHttpResponseLogger.cs" />
     <Compile Include="Interfaces\IPdfService.cs" />
     <Compile Include="Configuration\TokenServiceApiClientConfiguration.cs" />
     <Compile Include="Interfaces\IMultiVariantTestingService.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -22,7 +24,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.17615" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Notifications.Api.Client" version="2.0.0.35919" targetFramework="net462" />
   <package id="SFA.DAS.Notifications.Api.Types" version="2.0.0.35919" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
@@ -144,8 +144,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.0.0.34401\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>
@@ -186,11 +186,17 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Services\HmrcDateService.cs" />
     <Compile Include="Services\HmrcService.cs" />
     <Compile Include="Services\HttpClientWrapper.cs" />
+    <Compile Include="Services\HttpResponseLogger.cs" />
     <Compile Include="Services\PdfService.cs" />
     <Compile Include="Services\ReferenceDataService.cs" />
     <Compile Include="Services\RefreshEmployerLevyService.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
@@ -21,14 +21,10 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
         private readonly IHttpResponseLogger _httpResponseLogger;
 
-        public HttpClientWrapper(ILog logger)
+        public HttpClientWrapper(ILog logger, IHttpResponseLogger httpResponseLogger) 
         {
             _logger = logger;
             MediaTypeWithQualityHeaderValueList = new List<MediaTypeWithQualityHeaderValue>();
-        }
-
-        public HttpClientWrapper(ILog logger, IHttpResponseLogger httpResponseLogger) : this(logger)
-        {
             _httpResponseLogger = httpResponseLogger;
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
@@ -7,10 +7,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SFA.DAS.EAS.Domain.Http;
+using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Infrastructure.Services
-{
+{ 
     public class HttpClientWrapper : IHttpClientWrapper
     {
         public string AuthScheme { get; set; }
@@ -18,9 +19,12 @@ namespace SFA.DAS.EAS.Infrastructure.Services
         public List<MediaTypeWithQualityHeaderValue> MediaTypeWithQualityHeaderValueList { get; set; }
         private readonly ILog _logger;
 
-        public HttpClientWrapper(ILog logger)
+        private readonly IHttpResponseLogger _httpResponseLogger;
+
+        public HttpClientWrapper(ILog logger, IHttpResponseLogger httpResponseLogger)
         {
             _logger = logger;
+            _httpResponseLogger = httpResponseLogger;
             MediaTypeWithQualityHeaderValueList = new List<MediaTypeWithQualityHeaderValue>();
         }
 
@@ -33,7 +37,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
                 {
                     Content = new StringContent(serializeObject, Encoding.UTF8, "application/json")
                 });
-                EnsureSuccessfulResponse(response);
+                await EnsureSuccessfulResponse(response);
 
                 return await response.Content.ReadAsStringAsync();
             }
@@ -46,7 +50,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthScheme, authToken);
 
                 var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
-                EnsureSuccessfulResponse(response);
+                await EnsureSuccessfulResponse(response);
 
                 return JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
             }
@@ -64,7 +68,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
                 }
 
                 var response = await client.GetAsync(url);
-                EnsureSuccessfulResponse(response);
+                await EnsureSuccessfulResponse(response);
 
                 return response.Content.ReadAsStringAsync().Result;
             }
@@ -94,7 +98,7 @@ namespace SFA.DAS.EAS.Infrastructure.Services
             return httpClient;
         }
 
-        private void EnsureSuccessfulResponse(HttpResponseMessage response)
+        private async Task EnsureSuccessfulResponse(HttpResponseMessage response)
         {
             if (response.IsSuccessStatusCode)
             {
@@ -113,6 +117,10 @@ namespace SFA.DAS.EAS.Infrastructure.Services
                 case 503:
                     throw new ServiceUnavailableException();
                 default:
+                    if ((int) response.StatusCode == 400)
+                    {
+                        await _httpResponseLogger.LogResponseAsync(_logger, response);
+                    }
                     throw new HttpException((int)response.StatusCode, $"Unexpected HTTP exception - ({(int)response.StatusCode}): {response.ReasonPhrase}");
             }
         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpClientWrapper.cs
@@ -21,11 +21,15 @@ namespace SFA.DAS.EAS.Infrastructure.Services
 
         private readonly IHttpResponseLogger _httpResponseLogger;
 
-        public HttpClientWrapper(ILog logger, IHttpResponseLogger httpResponseLogger)
+        public HttpClientWrapper(ILog logger)
         {
             _logger = logger;
-            _httpResponseLogger = httpResponseLogger;
             MediaTypeWithQualityHeaderValueList = new List<MediaTypeWithQualityHeaderValue>();
+        }
+
+        public HttpClientWrapper(ILog logger, IHttpResponseLogger httpResponseLogger) : this(logger)
+        {
+            _httpResponseLogger = httpResponseLogger;
         }
 
         public async Task<string> SendMessage<T>(T content, string url)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpResponseLogger.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Services/HttpResponseLogger.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using SFA.DAS.EAS.Domain.Interfaces;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EAS.Infrastructure.Services
+{
+    public class HttpResponseLogger : IHttpResponseLogger
+    {
+        public async Task LogResponseAsync(ILog logger, HttpResponseMessage response)
+        {
+            if (IsContentStringType(response))
+            {
+                var content = await response.Content.ReadAsStringAsync();
+
+                logger.Debug("Logged response", new Dictionary<string, object>()
+                {
+                    { "StatusCode", response.StatusCode},
+                    { "Reason", response.ReasonPhrase },
+                    { "Content", content }
+                });
+            }
+        }
+
+        private bool IsContentStringType(HttpResponseMessage response)
+        {
+            return response?.Content?.Headers?.ContentType != null && (
+                       response.Content.Headers.ContentType.MediaType.StartsWith("text") ||
+                       response.Content.Headers.ContentType.MediaType == "application/json");
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/packages.config
@@ -7,6 +7,8 @@
   <package id="Dapper.Contrib" version="1.50.0" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -29,7 +31,7 @@
   <package id="SFA.DAS.CookieService" version="1.0.0.27423" targetFramework="net462" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net462" />
   <package id="SFA.DAS.ReferenceData.Api.Client" version="1.0.0.33424" targetFramework="net462" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/SFA.DAS.EAS.TestCommon.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/SFA.DAS.EAS.TestCommon.csproj
@@ -147,8 +147,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Notifications.Api.Client, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Notifications.Api.Client.2.0.0.35919\lib\net45\SFA.DAS.Notifications.Api.Client.dll</HintPath>
@@ -172,12 +172,18 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/packages.config
@@ -6,6 +6,8 @@
   <package id="Dapper" version="1.50.2" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net45" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net462" />
@@ -30,7 +32,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Notifications.Api.Client" version="2.0.0.35919" targetFramework="net45" />
   <package id="SFA.DAS.Notifications.Api.Types" version="1.1.0.12760" targetFramework="net45" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net45" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.AcceptanceTests/SFA.DAS.EAS.Web.AcceptanceTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.AcceptanceTests/SFA.DAS.EAS.Web.AcceptanceTests.csproj
@@ -157,8 +157,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.17615, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.17615\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Notifications.Api.Client, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Notifications.Api.Client.2.0.0.35919\lib\net45\SFA.DAS.Notifications.Api.Client.dll</HintPath>
@@ -182,6 +182,9 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -189,6 +192,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.AcceptanceTests/packages.config
@@ -5,6 +5,8 @@
   <package id="Dapper" version="1.50.2" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
@@ -31,7 +33,7 @@
   <package id="SFA.DAS.Http" version="1.0.0.35742" targetFramework="net45" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.17615" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.Notifications.Api.Client" version="2.0.0.35919" targetFramework="net45" />
   <package id="SFA.DAS.Notifications.Api.Types" version="2.0.0.35919" targetFramework="net45" />
   <package id="SFA.DAS.TimeProvider" version="1.0.0.3956" targetFramework="net45" />

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker.UnitTests/SFA.DAS.EAS.LevyDeclarationProvider.Worker.UnitTests.csproj
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker.UnitTests/SFA.DAS.EAS.LevyDeclarationProvider.Worker.UnitTests.csproj
@@ -58,12 +58,18 @@
     <Reference Include="SFA.DAS.Messaging, Version=3.0.0.51076, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.3.0.0.51076\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker.UnitTests/packages.config
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker.UnitTests/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NLog" version="4.3.7" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
 </packages>

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/SFA.DAS.EAS.LevyDeclarationProvider.Worker.csproj
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/SFA.DAS.EAS.LevyDeclarationProvider.Worker.csproj
@@ -141,8 +141,8 @@
     <Reference Include="SFA.DAS.Messaging.AzureServiceBus.StructureMap, Version=3.0.0.49552, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.StructureMap.3.0.0.49552\lib\net45\SFA.DAS.Messaging.AzureServiceBus.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.34273\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.34273\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
@@ -169,6 +169,10 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -176,6 +180,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/packages.config
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/packages.config
@@ -5,6 +5,8 @@
   <package id="AzureTableStorageNLogTarget" version="1.0.9" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net462" />
@@ -26,7 +28,7 @@
   <package id="SFA.DAS.Messaging" version="3.0.0.51076" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.0.0.49552" targetFramework="net462" />
   <package id="SFA.DAS.Messaging.AzureServiceBus.StructureMap" version="3.0.0.49552" targetFramework="net462" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.34273" targetFramework="net462" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net462" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net462" />
   <package id="SFA.DAS.TokenService.Api.Client" version="1.0.0.26382" targetFramework="net462" />


### PR DESCRIPTION
This adds response logging for bad requests. This is intended specifically to help with the bad requests that we're getting from HMRC but will log all bad requests.

It was necessary to upgrade das nlogger packages across the solution to the same version.