### PR TITLE
Aml 2098 trans down character length chrome

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
@@ -23,34 +23,34 @@
                 @Html.AntiForgeryToken()
                 @Html.HiddenFor(m => m.Message.HashedAccountId)
                 <div class="form-group @(Html.IsValid(m => m.Message.StartDate.Month) && Html.IsValid(m => m.Message.StartDate.Year) ? "" : "error")">
-                    <span id="StartDate" class="form-label-bold">Start date</span>
+                    <span id="@Html.IdFor(m => m.Message.StartDate)" class="form-label-bold">Start date</span>
                     <span class="form-hint">For example, 5 2017</span>
                     <div class="form-date">
                         @Html.ValidationMessageFor(m => m.Message.StartDate.Month)
                         @Html.ValidationMessageFor(m => m.Message.StartDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = "StartDate " + @Html.IdFor(m => m.Message.StartDate.Month)})
+                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = $"{Html.IdFor(m => m.Message.StartDate)} {Html.IdFor(m => m.Message.StartDate.Month)}" })
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = "StartDate " + @Html.IdFor(m => m.Message.StartDate.Year) })
+                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = $"{Html.IdFor(m => m.Message.StartDate)} {Html.IdFor(m => m.Message.StartDate.Year)}" })
                         </div>
                     </div>
                 </div>
                 <div class="form-group @(Html.IsValid(m => m.Message.EndDate.Month) && Html.IsValid(m => m.Message.EndDate.Year) ? "" : "error")">
-                    <span id="EndDate"  class="form-label-bold">End date</span>
+                    <span id="@Html.IdFor(m => m.Message.EndDate)" class="form-label-bold">End date</span>
                     <span class="form-hint">For example, 10 2017</span>
                     <div class="form-date">
                         @Html.ValidationMessageFor(m => m.Message.EndDate.Month)
                         @Html.ValidationMessageFor(m => m.Message.EndDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = "EndDate " + @Html.IdFor(m => m.Message.EndDate.Month) })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = $"{Html.IdFor(m => m.Message.EndDate)} {Html.IdFor(m => m.Message.EndDate.Month)}" })
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = "EndDate " + @Html.IdFor(m => m.Message.EndDate.Year) })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = $"{Html.IdFor(m => m.Message.EndDate)} {Html.IdFor(m => m.Message.EndDate.Year)}" })
                         </div>
                     </div>
                 </div>

--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
@@ -23,34 +23,34 @@
                 @Html.AntiForgeryToken()
                 @Html.HiddenFor(m => m.Message.HashedAccountId)
                 <div class="form-group @(Html.IsValid(m => m.Message.StartDate.Month) && Html.IsValid(m => m.Message.StartDate.Year) ? "" : "error")">
-                    <span class="form-label-bold">Start date</span>
+                    <span id="StartDate" class="form-label-bold">Start date</span>
                     <span class="form-hint">For example, 5 2017</span>
                     <div class="form-date">
                         @Html.ValidationMessageFor(m => m.Message.StartDate.Month)
                         @Html.ValidationMessageFor(m => m.Message.StartDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12" })
+                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = "StartDate " + @Html.IdFor(m => m.Message.StartDate.Month)})
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999" })
+                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = "StartDate " + @Html.IdFor(m => m.Message.StartDate.Year) })
                         </div>
                     </div>
                 </div>
                 <div class="form-group @(Html.IsValid(m => m.Message.EndDate.Month) && Html.IsValid(m => m.Message.EndDate.Year) ? "" : "error")">
-                    <span class="form-label-bold">End date</span>
+                    <span id="EndDate"  class="form-label-bold">End date</span>
                     <span class="form-hint">For example, 10 2017</span>
                     <div class="form-date">
                         @Html.ValidationMessageFor(m => m.Message.EndDate.Month)
                         @Html.ValidationMessageFor(m => m.Message.EndDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12" })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = "EndDate " + @Html.IdFor(m => m.Message.EndDate.Month) })
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999" })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999", aria_labelledby = "EndDate " + @Html.IdFor(m => m.Message.EndDate.Year) })
                         </div>
                     </div>
                 </div>

--- a/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerAccountTransactions/TransactionsDownload.cshtml
@@ -18,7 +18,7 @@
             <p>Enter a start and end date to download transactions within a specific date range.</p>
         </div>
         <div class="column-one-third">
-                @using (Html.BeginForm())
+            @using (Html.BeginForm("TransactionsDownload", "EmployerAccountTransactions", FormMethod.Post, new { novalidate = "novalidate" }))
             {
                 @Html.AntiForgeryToken()
                 @Html.HiddenFor(m => m.Message.HashedAccountId)
@@ -30,11 +30,11 @@
                         @Html.ValidationMessageFor(m => m.Message.StartDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control", type = "number", maxlength = "2" })
+                            @Html.TextBoxFor(m => m.Message.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12" })
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.StartDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control", type = "number", maxlength = "4" })
+                            @Html.TextBoxFor(m => m.Message.StartDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999" })
                         </div>
                     </div>
                 </div>
@@ -46,11 +46,11 @@
                         @Html.ValidationMessageFor(m => m.Message.EndDate.Year)
                         <div class="form-group">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Month)">Month</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control", type = "number", maxlength = "2" })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12" })
                         </div>
                         <div class="form-group form-group-year">
                             <label for="@Html.IdFor(m => m.Message.EndDate.Year)">Year</label>
-                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control", type = "number", maxlength = "4" })
+                            @Html.TextBoxFor(m => m.Message.EndDate.Year, new { @class = "form-control length-limit", type = "number", maxlength = "4", min = "1900", max = "9999" })
                         </div>
                     </div>
                 </div>
@@ -59,10 +59,10 @@
                     @Html.DropDownListFor(m => m.Message.DownloadFormat, EnumHelper.GetSelectList(typeof(DownloadFormatType)), new { @class = "form-control" })
                 </div>
                 <button class="button" aria-label="Download">Download</button>
-        }
-            </div>
+            }
         </div>
     </div>
+</div>
 
 @section breadcrumb {
     <div class="breadcrumbs">
@@ -72,4 +72,8 @@
             <li>@ViewBag.Title</li>
         </ol>
     </div>
+}
+
+@section pageSpecificJS {
+    <script src="~/dist/javascripts/length-limit.js"></script>
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetTransactionsDownloadTests/WhenIGetTransactionsDownload.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetTransactionsDownloadTests/WhenIGetTransactionsDownload.cs
@@ -23,9 +23,9 @@ namespace SFA.DAS.EAS.Application.UnitTests.Queries.GetTransactionsDownloadTests
         private const string ExternalUserId = "ABCDEF";
         private const long AccountId = 111111;
         private const long UserId = 222222;
-        private static readonly MonthYear StartDate = new MonthYear { Month = 1, Year = 2000 };
-        private static readonly MonthYear EndDate = new MonthYear { Month = 1, Year = 2000 };
-        private static readonly DateTime ToDate = new DateTime(EndDate.Year.Value, EndDate.Month.Value, 1).AddMonths(1);
+        private static readonly MonthYear StartDate = new MonthYear { Month = "1", Year = "2000" };
+        private static readonly MonthYear EndDate = new MonthYear { Month = "1", Year = "2000" };
+        private static readonly DateTime ToDate = new DateTime(2000, 2, 1);
 
         private GetTransactionsDownloadQueryHandler _handler;
         private GetTransactionsDownloadQuery _query;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/DateAttribute.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/DateAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using SFA.DAS.EAS.Application.Messages;
+
+namespace SFA.DAS.EAS.Application.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DateAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var now = DateTime.Now;
+            var today = now.Date;
+            var beginningOfTwentiethCentury = new DateTime(1900, 1, 1);
+            var lowercaseDisplayName = validationContext.DisplayName.ToLower();
+
+            if (value is DayMonthYear dayMonthYear)
+            {
+                if (dayMonthYear.Day?.Length <= 2 && dayMonthYear.Month?.Length <= 2 && dayMonthYear.Year?.Length <= 4)
+                {
+                    if (!dayMonthYear.IsValid())
+                    {
+                        return new ValidationResult($"Enter a different {lowercaseDisplayName}", new[] { nameof(dayMonthYear.Year) });
+                    }
+
+                    if (dayMonthYear > today)
+                    {
+                        return new ValidationResult($"The latest {lowercaseDisplayName} you can enter is {today:MM yyyy}", new[] { nameof(dayMonthYear.Year) });
+                    }
+
+                    if (dayMonthYear < beginningOfTwentiethCentury)
+                    {
+                        return new ValidationResult($"The earliest {lowercaseDisplayName} you can enter is {beginningOfTwentiethCentury:MM yyyy}", new[] { nameof(dayMonthYear.Year) });
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/DayAttribute.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/DayAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using SFA.DAS.EAS.Application.Messages;
+
+namespace SFA.DAS.EAS.Application.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DayAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var lowercaseDisplayName = validationContext.DisplayName.ToLower();
+            var dayMonthYear = value as DayMonthYear;
+            var day = dayMonthYear?.Day;
+
+            if (string.IsNullOrWhiteSpace(day))
+            {
+                return new ValidationResult($"Enter a {lowercaseDisplayName} day", new[] { nameof(dayMonthYear.Day) });
+            }
+
+            if (day.Length > 2)
+            {
+                return new ValidationResult($"{validationContext.DisplayName} day: 2 character limit", new[] { nameof(dayMonthYear.Day) });
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/MonthAttribute.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/MonthAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using SFA.DAS.EAS.Application.Messages;
+
+namespace SFA.DAS.EAS.Application.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class MonthAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var lowercaseDisplayName = validationContext.DisplayName.ToLower();
+            var dayMonthYear = value as DayMonthYear;
+            var month = dayMonthYear?.Month;
+
+            if (string.IsNullOrWhiteSpace(month))
+            {
+                return new ValidationResult($"Enter a {lowercaseDisplayName} month", new[] { nameof(dayMonthYear.Month) });
+            }
+
+            if (month.Length > 2)
+            {
+                return new ValidationResult($"{validationContext.DisplayName} month: 2 character limit", new[] { nameof(dayMonthYear.Month) });
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/YearAttribute.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Attributes/YearAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using SFA.DAS.EAS.Application.Messages;
+
+namespace SFA.DAS.EAS.Application.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class YearAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var lowercaseDisplayName = validationContext.DisplayName.ToLower();
+            var dayMonthYear = value as DayMonthYear;
+            var year = dayMonthYear?.Year;
+
+            if (string.IsNullOrWhiteSpace(year))
+            {
+                return new ValidationResult($"Enter a {lowercaseDisplayName} year", new[] { nameof(dayMonthYear.Year) });
+            }
+
+            if (year.Length > 4)
+            {
+                return new ValidationResult($"{validationContext.DisplayName} year: 4 character limit", new[] { nameof(dayMonthYear.Year) });
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/DayMonthYear.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/DayMonthYear.cs
@@ -1,20 +1,21 @@
 ﻿using System;
+using System.Globalization;
 
 namespace SFA.DAS.EAS.Application.Messages
 {
     public class DayMonthYear
     {
-        public int? Day { get; set; }
-        public int? Month { get; set; }
-        public int? Year { get; set; }
+        public virtual string Day { get; set; }
+        public virtual string Month { get; set; }
+        public virtual string Year { get; set; }
 
         public static implicit operator DayMonthYear(DateTime dateTime)
         {
             return new DayMonthYear
             {
-                Day = dateTime.Day,
-                Month = dateTime.Month,
-                Year = dateTime.Year
+                Day = dateTime.Day.ToString(),
+                Month = dateTime.Month.ToString(),
+                Year = dateTime.Year.ToString()
             };
         }
 
@@ -25,12 +26,12 @@ namespace SFA.DAS.EAS.Application.Messages
 
         public bool IsValid()
         {
-            return Day != null && Month != null && Year != null && DateTime.TryParse($"{Year}-{Month}-{Day}", out var _);
+            return Day != null && Month != null && Year != null && DateTime.TryParseExact($"{Year}-{Month}-{Day}", "yyyy-M-d", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime _);
         }
 
         public DateTime ToDate()
         {
-            return new DateTime(Year.Value, Month.Value, Day.Value, 0, 0, 0);
+            return new DateTime(int.Parse(Year), int.Parse(Month), int.Parse(Day), 0, 0, 0);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/MonthYear.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/MonthYear.cs
@@ -4,17 +4,14 @@ namespace SFA.DAS.EAS.Application.Messages
 {
     public class MonthYear : DayMonthYear
     {
-        public MonthYear()
-        {
-            Day = 1;
-        }
+        public override string Day => 1.ToString();
 
         public static implicit operator MonthYear(DateTime dateTime)
         {
             return new MonthYear
             {
-                Month = dateTime.Month,
-                Year = dateTime.Year
+                Month = dateTime.Month.ToString(),
+                Year = dateTime.Year.ToString()
             };
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/Year.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Messages/Year.cs
@@ -4,17 +4,14 @@ namespace SFA.DAS.EAS.Application.Messages
 {
     public class Year : DayMonthYear
     {
-        public Year()
-        {
-            Day = 1;
-            Month = 1;
-        }
+        public override string Day => 1.ToString();
+        public override string Month => 1.ToString();
 
         public static implicit operator Year(DateTime dateTime)
         {
             return new Year
             {
-                Year = dateTime.Year
+                Year = dateTime.Year.ToString()
             };
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetTransactionsDownload/GetTransactionsDownloadQuery.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetTransactionsDownload/GetTransactionsDownloadQuery.cs
@@ -1,87 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Globalization;
+﻿using System.ComponentModel.DataAnnotations;
 using MediatR;
+using SFA.DAS.EAS.Application.Attributes;
 using SFA.DAS.EAS.Application.Formatters.TransactionDowloads;
-using SFA.DAS.EAS.Application.Helpers;
 using SFA.DAS.EAS.Application.Messages;
 using SFA.DAS.EAS.Domain;
 
 namespace SFA.DAS.EAS.Application.Queries.GetTransactionsDownload
 {
-    public class GetTransactionsDownloadQuery : IAsyncRequest<GetTransactionsDownloadResponse>, IValidatableObject
+    public class GetTransactionsDownloadQuery : IAsyncRequest<GetTransactionsDownloadResponse>
     {
         [Required]
         [RegularExpression(Constants.HashedAccountIdRegex)]
         public string HashedAccountId { get; set; }
 
+        [Display(Name = "Start date")]
         [Required]
+        [Month, Year, Date]
         public MonthYear StartDate { get; set; }
 
+        [Display(Name = "End date")]
         [Required]
+        [Month, Year, Date]
         public MonthYear EndDate { get; set; }
 
         [Required]
         public DownloadFormatType? DownloadFormat { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            var now = DateTime.Now;
-            var today = now.Date;
-            
-            if (StartDate.Month == null)
-            {
-                yield return new ValidationResult("Enter a start month", new[] { NameOf.Property(this, q => q.StartDate.Month) });
-            }
-
-            if (StartDate.Year == null)
-            {
-                yield return new ValidationResult("Enter a start year", new[] { NameOf.Property(this, q => q.StartDate.Year) });
-            }
-                
-            if (StartDate.Month != null && StartDate.Year != null && !StartDate.IsValid())
-            {
-                yield return new ValidationResult("Enter a different start date", new[] { NameOf.Property(this, q => q.StartDate.Month) });
-            }
-                
-            if (StartDate.Month != null && StartDate.Year != null && StartDate.IsValid() && StartDate > today)
-            {
-                yield return new ValidationResult($"The latest start date you can enter is {today:MM yyyy}", new[] { NameOf.Property(this, q => q.StartDate.Month) });
-            }
-
-            if (EndDate.Month == null)
-            {
-                yield return new ValidationResult("Enter an end month", new[] { NameOf.Property(this, q => q.EndDate.Month) });
-            }
-
-            if (EndDate.Year == null)
-            {
-                yield return new ValidationResult("Enter an end year", new[] { NameOf.Property(this, q => q.EndDate.Year) });
-            }
-
-            if (EndDate.Month != null && EndDate.Year != null && !EndDate.IsValid())
-            {
-                yield return new ValidationResult("Enter a different end date", new[] { NameOf.Property(this, q => q.EndDate.Month) });
-            }
-
-            if (EndDate.Month != null && EndDate.Year != null && EndDate.IsValid() && EndDate > today)
-            {
-                yield return new ValidationResult($"The latest end date you can enter is {today:MM yyyy}", new[] { NameOf.Property(this, q => q.EndDate.Month) });
-            }
-
-            var earliestDate = DateTime.ParseExact("19000101", "yyyyMMdd", CultureInfo.InvariantCulture);
-
-            if (EndDate.Month != null && EndDate.Year != null && EndDate.IsValid() && EndDate < earliestDate)
-            {
-                yield return new ValidationResult($"The earliest end date you can enter is {earliestDate:MM yyyy}", new[] { NameOf.Property(this, q => q.EndDate.Month) });
-            }
-
-            if (StartDate.Month != null && StartDate.Year != null && StartDate.IsValid() && StartDate < earliestDate)
-            {
-                yield return new ValidationResult($"The earliest start date you can enter is {earliestDate:MM yyyy}", new[] { NameOf.Property(this, q => q.StartDate.Month) });
-            }
-
-        }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetTransactionsDownload/GetTransactionsDownloadQueryHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetTransactionsDownload/GetTransactionsDownloadQueryHandler.cs
@@ -42,8 +42,9 @@ namespace SFA.DAS.EAS.Application.Queries.GetTransactionsDownload
             }
             
             var accountId = _hashingService.DecodeValue(message.HashedAccountId);
-            var toDate = new DateTime(message.EndDate.Year.Value, message.EndDate.Month.Value, 1).AddMonths(1);
-            var transactions = await _transactionRepository.GetAllTransactionDetailsForAccountByDate(accountId, message.StartDate, toDate);
+            var endDate = message.EndDate.ToDate();
+            var endDateBeginningOfNextMonth = new DateTime(endDate.Year, endDate.Month, 1).AddMonths(1);
+            var transactions = await _transactionRepository.GetAllTransactionDetailsForAccountByDate(accountId, message.StartDate, endDateBeginningOfNextMonth);
 
             if (!transactions.Any())
             {

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
@@ -235,6 +235,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApprenticeshipInfoServiceWrapper.cs" />
+    <Compile Include="Attributes\DateAttribute.cs" />
+    <Compile Include="Attributes\DayAttribute.cs" />
+    <Compile Include="Attributes\YearAttribute.cs" />
+    <Compile Include="Attributes\MonthAttribute.cs" />
     <Compile Include="Commands\SendTransferConnectionInvitation\SendTransferConnectionInvitationCommand.cs" />
     <Compile Include="Commands\DismissMonthlyTaskReminder\DismissMonthlyTaskReminderCommand.cs" />
     <Compile Include="Commands\DismissMonthlyTaskReminder\DismissMonthlyTaskReminderCommandHandler.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountTransactionsControllerTests/WhenIDownloadTransactionsByDate.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/EmployerAccountTransactionsControllerTests/WhenIDownloadTransactionsByDate.cs
@@ -47,13 +47,13 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.EmployerAccountTransactionsContr
                 {
                     StartDate = new MonthYear
                     {
-                        Month = 1,
-                        Year = 2000
+                        Month = "1",
+                        Year = "2000"
                     },
                     EndDate = new MonthYear
                     {
-                        Month = 1,
-                        Year = 2018
+                        Month = "1",
+                        Year = "2018"
                     }
                 }
             };


### PR DESCRIPTION
I have created this pull request for discussion.

I have added an attribute to the Form novalidate = "novalidate" this prevents the browser from blocking a post back should the client be aware a field is invalid. (It removes the client side tooltip warning on the box).

I have re-added in client side max and min values onto the Html inputs, these no longer create copy problems because of the novalidate attribute now added to the form.

I have added in the aria_labelledby elements and made sure all of the id's used to bind labels, accessibility and inputs are the same. I have tested this in the narrator and Now get "End Date - Month" as speech when I click into that field.

Finally - the controversial point - I have added in some page specific javascript. Chrome - correctly - ignores min and max on input type="number" but the other browsers don't. Comittments currently use this block of javascript to create the min and max behaviour on an input. Validation is consistent with or without the script, with it in chrome we now are stopped from entering six digit years for example.

What are we doing going forward with javascript - None or Some if it adds value?