### PR TITLE
ER 217 Add Recruit links

### DIFF
--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
@@ -29,6 +29,7 @@
       <Setting name="ShowPayeHistory" />
       <Setting name="CurrentTime" />
       <Setting name="EmployerCommitmentsBaseUrl" />
+      <Setting name="EmployerRecruitBaseUrl" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" />

--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
@@ -28,6 +28,7 @@
       <Setting name="ShowPayeHistory" />
       <Setting name="CurrentTime" />
       <Setting name="EmployerCommitmentsBaseUrl" />
+      <Setting name="EmployerRecruitBaseUrl" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" loadBalancer="das-prd-eas-ilb"/>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -16,6 +16,7 @@
       <Setting name="ShowPayeHistory" value="true" />
       <Setting name="CurrentTime" value="" />
       <Setting name="EmployerCommitmentsBaseUrl" value="__EmployerCommitmentsBaseUrl__" />
+      <Setting name="EmployerRecruitBaseUrl" value="__EmployerRecruitBaseUrl__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="E280E23D933FE3A62AF335BE9768A2C9D65CCC9A" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
@@ -16,6 +16,7 @@
       <Setting name="ShowPayeHistory" value="true" />
       <Setting name="CurrentTime" value="" />
       <Setting name="EmployerCommitmentsBaseUrl" value="" />
+      <Setting name="EmployerRecruitBaseUrl" value="http://localhost:5020/" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="CE71D8AD4A859BD1803DBE03989801B56E5B6875" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -16,6 +16,7 @@
       <Setting name="ShowPayeHistory" value="false" />
       <Setting name="CurrentTime" value="" />
       <Setting name="EmployerCommitmentsBaseUrl" value="__EmployerCommitmentsBaseUrl__" />
+      <Setting name="EmployerRecruitBaseUrl" value="__EmployerRecruitBaseUrl__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="EDCEF8D64D09C1D1FEDFD534CACB55E0437CFAD3" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
@@ -16,6 +16,7 @@
       <Setting name="ShowPayeHistory" value="false" />
       <Setting name="CurrentTime" value="" />
       <Setting name="EmployerCommitmentsBaseUrl" value="__EmployerCommitmentsBaseUrl__" />
+      <Setting name="EmployerRecruitBaseUrl" value="__EmployerRecruitBaseUrl__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="BF55F64F778FC5F4E4EEBAE6493E37464B3E2AD7" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceDefinition.csdef
+++ b/src/SFA.DAS.CloudService/ServiceDefinition.csdef
@@ -29,6 +29,7 @@
       <Setting name="ShowPayeHistory" />
       <Setting name="CurrentTime" />
       <Setting name="EmployerCommitmentsBaseUrl" />
+      <Setting name="EmployerRecruitBaseUrl" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" />

--- a/src/SFA.DAS.EAS.Web/Extensions/UrlHelperExtensions.cs
+++ b/src/SFA.DAS.EAS.Web/Extensions/UrlHelperExtensions.cs
@@ -6,11 +6,22 @@ namespace SFA.DAS.EAS.Web.Extensions
 {
     public static class UrlHelperExtensions
     {
-        public static string ExternalAction(this UrlHelper helper, string controllerName, string actionName = "")
+        public static string EmployerCommitmentsAction(this UrlHelper helper, string controllerName, string actionName = "")
         {
             var baseUrl = CloudConfigurationManager.GetSetting(ControllerConstants.EmployerCommitmentsBaseUrlKeyName).EndsWith("/")
                 ? CloudConfigurationManager.GetSetting(ControllerConstants.EmployerCommitmentsBaseUrlKeyName)
                 : CloudConfigurationManager.GetSetting(ControllerConstants.EmployerCommitmentsBaseUrlKeyName) + "/";
+
+            var accountId = helper.RequestContext.RouteData.Values[ControllerConstants.HashedAccountIdKeyName];
+
+            return $"{baseUrl}accounts/{accountId}/{controllerName}/{actionName}";
+        }
+
+        public static string EmployerRecruitAction(this UrlHelper helper, string controllerName, string actionName = "")
+        {
+            var baseUrl = CloudConfigurationManager.GetSetting(ControllerConstants.EmployerRecruitControllerName).EndsWith("/")
+                ? CloudConfigurationManager.GetSetting(ControllerConstants.EmployerRecruitControllerName)
+                : CloudConfigurationManager.GetSetting(ControllerConstants.EmployerRecruitControllerName) + "/";
 
             var accountId = helper.RequestContext.RouteData.Values[ControllerConstants.HashedAccountIdKeyName];
 

--- a/src/SFA.DAS.EAS.Web/Helpers/ControllerConstants.cs
+++ b/src/SFA.DAS.EAS.Web/Helpers/ControllerConstants.cs
@@ -27,6 +27,7 @@
         public const string EmployerCommitmentsBaseUrlKeyName = "EmployerCommitmentsBaseUrl";
         public const string EmployerTeamActionName = "EmployerTeam";
         public const string EmployerTeamControllerName = "EmployerTeam";
+        public const string EmployerRecruitControllerName = "EmployerRecruitBaseUrl";
         public const string ErrorControllerName = "Error";
         public const string FeatureNotEnabledViewName = "FeatureNotEnabled";
         public const string FindAddressViewName = "../OrganisationShared/FindAddress";

--- a/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerTeam/Index.cshtml
@@ -45,7 +45,7 @@ else
                     <p>Add your organisations that will make contracts with training providers.</p>
 
                     <h2 class="heading-medium">
-                        <a href="@Url.ExternalAction("apprentices", "home")">Apprentices</a>
+                        <a href="@Url.EmployerCommitmentsAction("apprentices", "home")">Apprentices</a>
                     </h2>
                     <p>Add apprentices, update details of existing apprentices and authorise payments to training providers.</p>
                 </div>
@@ -58,11 +58,19 @@ else
                         <a href="@Url.Action("Index", "EmployerAccountPaye")">PAYE schemes</a>
                     </h2>
                     <p>Add or remove <abbr title="Pay as your earn">PAYE</abbr> schemes.</p>
-          
+
                     <h2 class="heading-medium">
                         <a href="https://findapprenticeshiptraining.sfa.bis.gov.uk/" target="_blank" rel="external">Find apprenticeship training</a>
                     </h2>
                     <p>Search for apprenticeships and see details of approved providers who can deliver the training.</p>
+
+                    @if (Html.IsFeatureEnabled("Recruit", "Index"))
+                    {
+                        <h2 class="heading-medium">
+                            <a href="@Url.EmployerRecruitAction("dashboard")">Apprenticeship recruitment</a>
+                        </h2>
+                        <p>Create vacancies to appear on Find an apprenticeship to attract candidates.</p>
+                    }
                 </div>
             </div>
             <div class="grid-row">
@@ -118,17 +126,17 @@ else
                                                 break;
                                             case "AddApprentices":
                                                 <p>
-                                                    <a href="@Url.ExternalAction("apprentices", "Inform")">Start adding apprentices now</a>
+                                                    <a href="@Url.EmployerCommitmentsAction("apprentices", "Inform")">Start adding apprentices now</a>
                                                 </p>
                                                 break;
                                             case "ApprenticeChangesToReview":
                                                 <p>
-                                                    @task.ItemsDueCount apprentice change@(task.ItemsDueCount > 1 ? "s" : "") to review <a href="@Url.ExternalAction("apprentices", "manage/all?RecordStatus=ChangesForReview")">View changes</a>
+                                                    @task.ItemsDueCount apprentice change@(task.ItemsDueCount > 1 ? "s" : "") to review <a href="@Url.EmployerCommitmentsAction("apprentices", "manage/all?RecordStatus=ChangesForReview")">View changes</a>
                                                 </p>
                                                 break;
                                             case "CohortRequestReadyForApproval":
                                                 <p>
-                                                    @task.ItemsDueCount cohort request@(task.ItemsDueCount > 1 ? "s" : "") ready for approval <a href="@Url.ExternalAction("apprentices", "cohorts/review")">View cohorts</a>
+                                                    @task.ItemsDueCount cohort request@(task.ItemsDueCount > 1 ? "s" : "") ready for approval <a href="@Url.EmployerCommitmentsAction("apprentices", "cohorts/review")">View cohorts</a>
                                                 </p>
                                                 break;
                                         }

--- a/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
@@ -179,7 +179,7 @@
                     <ul role="menubar" id="global-nav-links">
                         <li><a href="@Url.Action("Index", "EmployerTeam")" class="@(ViewBag.Section == "home" ? "selected" : "")"  role="menuitem">Home</a></li>
                         <li><a href="@Url.Action("Index", "EmployerAccountTransactions")" class="@(ViewBag.Section == "finance" ? "selected" : "")" role="menuitem">Finance</a></li>
-                        <li><a href="@Url.ExternalAction("apprentices", "home")" class="@(controllerString == "EmployerCommitments" ? "selected" : "")" role="menuitem">Apprentices</a></li>
+                        <li><a href="@Url.EmployerCommitmentsAction("apprentices", "home")" class="@(controllerString == "EmployerCommitments" ? "selected" : "")" role="menuitem">Apprentices</a></li>
                         <li><a href="@Url.Action("ViewTeam", "EmployerTeam")" class="@(ViewBag.Section == "team" ? "selected" : "")" role="menuitem">Your team</a></li>
                         <li><a href="@Url.Action("Index", "EmployerAgreement")" class="@(ViewBag.Section == "organisations" ? "selected" : "")" role="menuitem">Your organisations and agreements</a></li>
                         <li><a href="@Url.Action("Index", "EmployerAccountPaye")" class="@(ViewBag.Section == "paye" ? "selected" : "")" role="menuitem">PAYE schemes</a></li>

--- a/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
@@ -177,8 +177,12 @@
             <div class="header-organisation" role="navigation">
                 <nav class="header-inner">
                     <ul role="menubar" id="global-nav-links">
-                        <li><a href="@Url.Action("Index", "EmployerTeam")" class="@(ViewBag.Section == "home" ? "selected" : "")"  role="menuitem">Home</a></li>
+                        <li><a href="@Url.Action("Index", "EmployerTeam")" class="@(ViewBag.Section == "home" ? "selected" : "")" role="menuitem">Home</a></li>
                         <li><a href="@Url.Action("Index", "EmployerAccountTransactions")" class="@(ViewBag.Section == "finance" ? "selected" : "")" role="menuitem">Finance</a></li>
+                        @if (Html.IsFeatureEnabled("Recruit", "Index"))
+                        {
+                            <li><a href="@Url.EmployerRecruitAction("dashboard")" role="menuitem">Recruit</a></li>
+                        }
                         <li><a href="@Url.EmployerCommitmentsAction("apprentices", "home")" class="@(controllerString == "EmployerCommitments" ? "selected" : "")" role="menuitem">Apprentices</a></li>
                         <li><a href="@Url.Action("ViewTeam", "EmployerTeam")" class="@(ViewBag.Section == "team" ? "selected" : "")" role="menuitem">Your team</a></li>
                         <li><a href="@Url.Action("Index", "EmployerAgreement")" class="@(ViewBag.Section == "organisations" ? "selected" : "")" role="menuitem">Your organisations and agreements</a></li>


### PR DESCRIPTION
Added Section and menu item for Employer Recruit links.

Added new Cloud config value. (To be set to the Employer Recruit site in each environment):
`<Setting name="EmployerRecruitBaseUrl" value="" />`

This feature will initially be switched off in production so the following feature toggle needs adding in table storage (exception being Dev environment):

        {
            "Controller": "Recruit",
            "Action": "Index",
            "Whitelist": []
        }

