### PR TITLE
Sink exception when fetching latest activities on dashboard

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/ActivitiesController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/ActivitiesController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Web.Mvc;
 using AutoMapper;
 using MediatR;
@@ -36,10 +37,17 @@ namespace SFA.DAS.EAS.Web.Controllers
         [Route("latest")]
         public ActionResult Latest(GetLatestActivitiesQuery query)
         {
-            var response = Task.Run(async () => await _mediator.SendAsync(query)).Result;
-            var model = _mapper.Map<LatestActivitiesViewModel>(response);
+            try
+            {
+                var response = _mediator.Send(query).Result;
+                var model = _mapper.Map<LatestActivitiesViewModel>(response);
 
-            return PartialView(model);
+                return PartialView(model);
+            }
+            catch (Exception e)
+            {
+                return Content("Activities are currently unavailable.");
+            }
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheActivitiesPage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheActivitiesPage.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using SFA.DAS.EAS.Application.Queries.GetActivities;
 using SFA.DAS.EAS.Web.Controllers;
 using SFA.DAS.EAS.Web.ViewModels.Activities;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
 {
@@ -16,6 +17,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
         private ActivitiesController _controller;
         private readonly Mock<IMediator> _mediator = new Mock<IMediator>();
         private readonly Mock<IMapper> _mapper = new Mock<IMapper>();
+        private readonly Mock<ILog> _logger = new Mock<ILog>();
         private readonly GetActivitiesQuery _query = new GetActivitiesQuery();
         private readonly GetActivitiesResponse _response = new GetActivitiesResponse();
         private readonly ActivitiesViewModel _viewModel = new ActivitiesViewModel();
@@ -26,7 +28,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
             _mediator.Setup(m => m.SendAsync(_query)).ReturnsAsync(_response);
             _mapper.Setup(m => m.Map<ActivitiesViewModel>(_response)).Returns(_viewModel);
 
-            _controller = new ActivitiesController(_mapper.Object, _mediator.Object);
+            _controller = new ActivitiesController(_mapper.Object, _mediator.Object, _logger.Object);
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheLatestActivitiesPage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheLatestActivitiesPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System;
+using System.Web.Mvc;
 using AutoMapper;
 using MediatR;
 using Moq;
@@ -6,6 +7,7 @@ using NUnit.Framework;
 using SFA.DAS.EAS.Application.Queries.GetLatestActivities;
 using SFA.DAS.EAS.Web.Controllers;
 using SFA.DAS.EAS.Web.ViewModels.Activities;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
 {
@@ -15,6 +17,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
         private ActivitiesController _controller;
         private readonly Mock<IMediator> _mediator = new Mock<IMediator>();
         private readonly Mock<IMapper> _mapper = new Mock<IMapper>();
+        private readonly Mock<ILog> _logger = new Mock<ILog>();
         private readonly GetLatestActivitiesQuery _query = new GetLatestActivitiesQuery();
         private readonly GetLatestActivitiesResponse _response = new GetLatestActivitiesResponse();
         private readonly LatestActivitiesViewModel _viewModel = new LatestActivitiesViewModel();
@@ -25,7 +28,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
             _mediator.Setup(m => m.SendAsync(_query)).ReturnsAsync(_response);
             _mapper.Setup(m => m.Map<LatestActivitiesViewModel>(_response)).Returns(_viewModel);
 
-            _controller = new ActivitiesController(_mapper.Object, _mediator.Object);
+            _controller = new ActivitiesController(_mapper.Object, _mediator.Object, _logger.Object);
         }
 
         [Test]
@@ -46,6 +49,33 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
             Assert.That(result.ViewName, Is.EqualTo(""));
             Assert.That(model, Is.Not.Null);
             Assert.That(model, Is.SameAs(_viewModel));
+        }
+
+        [Test]
+        public void ThenResponseShouldBeEmptyWhenExceptionIsThrown()
+        {
+            // Arrange
+            _mediator.Setup(m => m.Send(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
+
+            // Act
+            var result = _controller.Latest(_query) as ContentResult;
+            
+            // Arrange
+            Assert.AreEqual(ActivitiesController.ActivitiesUnavailableMessage, result?.Content);
+        }
+
+
+        [Test]
+        public void ThenExceptionShouldBeLoggedWhenExceptionIsThrown()
+        {
+            // Arrange
+            _mediator.Setup(m => m.Send(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
+
+            // Act
+            var result = _controller.Latest(_query);
+
+            // Arrange
+            _logger.Verify(l => l.Warn(It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheLatestActivitiesPage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/ActivitiesControllerTests/WhenIViewTheLatestActivitiesPage.cs
@@ -55,7 +55,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
         public void ThenResponseShouldBeEmptyWhenExceptionIsThrown()
         {
             // Arrange
-            _mediator.Setup(m => m.Send(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
+            _mediator.Setup(m => m.SendAsync(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
 
             // Act
             var result = _controller.Latest(_query) as ContentResult;
@@ -69,7 +69,7 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.ActivitiesControllerTests
         public void ThenExceptionShouldBeLoggedWhenExceptionIsThrown()
         {
             // Arrange
-            _mediator.Setup(m => m.Send(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
+            _mediator.Setup(m => m.SendAsync(It.IsAny<GetLatestActivitiesQuery>())).Throws<Exception>();
 
             // Act
             var result = _controller.Latest(_query);


### PR DESCRIPTION
This sinks exceptions when rendering the latest activities on the dashboard page.