### PR TITLE
Date format in transaction download fixed to dd/MM/yyyy

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/CsvTransactionFormatterTests.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/CsvTransactionFormatterTests.cs
@@ -54,7 +54,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Formatters.Transactions
         [Test]
         public void WhenICallGetContentsIGetCorrectDataFormat()
         {
-            var formattedFileData = PaymentFormatter.GetFileData(TransactionDownloadLines);
+            var formattedFileData = PaymentFormatter.GetFileData(TransactionDownloadLines); 
 
             var formattedFileContent = Encoding.UTF8.GetString(formattedFileData);
 
@@ -72,7 +72,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Formatters.Transactions
                 // We should be able to extract known values from each row
                 var dataRow = rows[Convert.ToInt32(i)].Split(char.Parse(","));
 
-                Assert.AreEqual(DateTime.Today.AddMonths(Convert.ToInt32(-i)), DateTime.Parse(dataRow[0]));
+                Assert.AreEqual(DateTime.Today.AddMonths(Convert.ToInt32(-i)).ToString("dd/MM/yyyy"), dataRow[0]);
                 Assert.AreEqual($"{TransactionTypePrefix}{i}", dataRow[1]);
                 Assert.AreEqual($"{EmpRefPrefix}{i}", dataRow[2]);
                 Assert.AreEqual($"{PeriodEndPrefix}{i}", dataRow[3]);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/ExcelTransactionFormatterTests/WhenICreateAExcelFile.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/ExcelTransactionFormatterTests/WhenICreateAExcelFile.cs
@@ -57,7 +57,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Formatters.Transactions.ExcelTransac
                 },
                 new[]
                 {
-                    _transactionLine.DateCreated.ToString(), _transactionLine.TransactionType,
+                    _transactionLine.DateCreated.ToString("dd/MM/yyyy"), _transactionLine.TransactionType,
                     _transactionLine.PayeScheme, _transactionLine.PeriodEnd, _transactionLine.LevyDeclaredFormatted,
                     _transactionLine.EnglishFractionFormatted, _transactionLine.TenPercentTopUpFormatted,
                     _transactionLine.TrainingProvider, _transactionLine.Uln,

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/CsvTransactionFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/CsvTransactionFormatter.cs
@@ -55,7 +55,7 @@ namespace SFA.DAS.EAS.Application.Formatters.TransactionDowloads
         {
             foreach (var transaction in transactions)
             {
-                builder.Append($"{transaction.DateCreated:G},");
+                builder.Append($"{transaction.DateCreated:dd/MM/yyyy},");
                 builder.Append($"{transaction.TransactionType},");
                 builder.Append($"{transaction.PayeScheme},");
                 builder.Append($"{transaction.PeriodEnd},");

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/ExcelTransactionFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/ExcelTransactionFormatter.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.EAS.Application.Formatters.TransactionDowloads
 
             excelRows.AddRange(transactions.Select(transaction => new[]
             {
-                transaction.DateCreated.ToString("G"),
+                transaction.DateCreated.ToString("dd/MM/yyyy"),
                 transaction.TransactionType,
                 transaction.PayeScheme,
                 transaction.PeriodEnd,


### PR DESCRIPTION
Different environments have different locales (Test is yielding MM/dd/yyy), this commit hard-codes the date output format in the transaction download to be "dd/MM/yyyy".