### PR TITLE
Aml 2038 update hmrc service.cs to use nuget package

### DIFF
--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
@@ -65,6 +65,12 @@
       <HintPath>..\packages\FluentAssertions.4.17.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Client, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Client.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="MediatR, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MediatR.2.1.0\lib\net45\MediatR.dll</HintPath>
       <Private>True</Private>

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcServiceTests/WhenICallTheHmrcServiceForAuthentication.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Services/HmrcServiceTests/WhenICallTheHmrcServiceForAuthentication.cs
@@ -1,12 +1,11 @@
 ﻿using System.Threading.Tasks;
 using System.Web;
+using HMRC.ESFA.Levy.Api.Client;
 using Moq;
 using Newtonsoft.Json;
-using NLog;
 using NUnit.Framework;
 using SFA.DAS.EAS.Domain.Configuration;
 using SFA.DAS.EAS.Domain.Http;
-using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Infrastructure.Services;
 using SFA.DAS.TokenService.Api.Client;
@@ -23,6 +22,7 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HmrcServiceTests
         private string ExpectedOgdClientId = "123456789";
         private string ExpectedScope = "emp_ref";
         private Mock<IHttpClientWrapper> _httpClientWrapper;
+        private Mock<IApprenticeshipLevyApiClient> _apprenticeshipLevyApiClient;
         private string ExpectedClientSecret = "my_secret";
         private const string ExpectedAccessCode = "789654321AGFVD";
         private Mock<ITokenServiceApiClient> _tokenService;
@@ -48,7 +48,10 @@ namespace SFA.DAS.EAS.Infrastructure.UnitTests.Services.HmrcServiceTests
             _tokenService = new Mock<ITokenServiceApiClient>();
             _tokenService.Setup(x => x.GetPrivilegedAccessTokenAsync()).ReturnsAsync(new PrivilegedAccessToken { AccessCode = ExpectedAccessCode });
 
-            _hmrcService = new HmrcService(_configuration, _httpClientWrapper.Object, _tokenService.Object, new NoopExecutionPolicy(), null,null);
+            _apprenticeshipLevyApiClient = new Mock<IApprenticeshipLevyApiClient>();
+
+            _hmrcService = new HmrcService(_configuration, _httpClientWrapper.Object,
+                _apprenticeshipLevyApiClient.Object, _tokenService.Object, new NoopExecutionPolicy(), null, null);
         }
 
         [Test]

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/packages.config
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/packages.config
@@ -8,6 +8,8 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
   <package id="FastMember.Signed" version="1.1.0" targetFramework="net462" />
   <package id="FluentAssertions" version="4.17.0" targetFramework="net45" />
+  <package id="HMRC.ESFA.Levy.Api.Client" version="1.0.43" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests.csproj
+++ b/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests.csproj
@@ -39,6 +39,9 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="MediatR, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MediatR.2.1.0\lib\net45\MediatR.dll</HintPath>
     </Reference>

--- a/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/Steps/LevyDeclarationWorkerSteps/LevyDeclarationWorkerSteps.cs
+++ b/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/Steps/LevyDeclarationWorkerSteps/LevyDeclarationWorkerSteps.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using HMRC.ESFA.Levy.Api.Types;
 using SFA.DAS.EAS.Application.Queries.GetHMRCLevyDeclaration;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.TestCommon.ScenarioCommonSteps;
 using TechTalk.SpecFlow;
 
@@ -47,7 +48,7 @@ namespace SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests2.Steps.LevyDeclarationW
                                 DateCeased = string.IsNullOrEmpty(row["DateCeased"]) ? default(DateTime) : Convert.ToDateTime(row["DateCeased"]),
                                 LevyDueYearToDate = string.IsNullOrEmpty(row["LevyDueYTD"]) ? 0 : Convert.ToDecimal(row["LevyDueYTD"]),
                                 NoPaymentForPeriod = !string.IsNullOrEmpty(row["NoPaymentForPeriod"]) && Convert.ToBoolean(row["NoPaymentForPeriod"]),
-                                SubmissionTime = row["SubmissionTime"],
+                                SubmissionTime = string.IsNullOrEmpty(row["SubmissionTime"]) ? default(DateTime) : DateTime.ParseExact(row["SubmissionTime"], "yyyy-MM-dd", CultureInfo.InvariantCulture),
                                 LevyAllowanceForFullYear = string.IsNullOrEmpty(row["LevyAllowanceForFullYear"]) ? 0 : Convert.ToDecimal(row["LevyAllowanceForFullYear"]),
                                 PayrollPeriod = new PayrollPeriod
                                 {

--- a/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.EAS.Levy.HmrcScenarios.AcceptanceTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EAS.Web/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.EAS.Web/DependencyResolution/IoC.cs
@@ -11,6 +11,7 @@ namespace SFA.DAS.EAS.Web.DependencyResolution
             return new Container(c =>
             {
                 c.AddRegistry<ActivitiesClientRegistry>();
+                c.AddRegistry<ApprenticeshipLevyRegistry>();
                 c.AddRegistry<AuditRegistry>();
                 c.AddRegistry<AuthorizationRegistry>();
                 c.AddRegistry<CachesRegistry>();

--- a/src/SFA.DAS.EAS.Web/SFA.DAS.EAS.Web.csproj
+++ b/src/SFA.DAS.EAS.Web/SFA.DAS.EAS.Web.csproj
@@ -77,6 +77,12 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Client, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Client.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="HtmlTags, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.6.0.0\lib\net45\HtmlTags.dll</HintPath>
     </Reference>

--- a/src/SFA.DAS.EAS.Web/packages.config
+++ b/src/SFA.DAS.EAS.Web/packages.config
@@ -12,6 +12,8 @@
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net462" />
   <package id="FluentValidation.MVC5" version="6.2.1.0" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Client" version="1.0.43" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
   <package id="IdentityModel" version="1.11.0" targetFramework="net462" />
   <package id="IdentityServer3" version="2.5.1" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Commands/UpdateEnglishFractions/WhenISendTheUpdateEnglishFractionsCommand.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Commands/UpdateEnglishFractions/WhenISendTheUpdateEnglishFractionsCommand.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using HMRC.ESFA.Levy.Api.Types;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.EAS.Application.Commands.UpdateEnglishFractions;
 using SFA.DAS.EAS.Application.Queries.GetEnglishFractionUpdateRequired;
 using SFA.DAS.EAS.Domain.Data.Repositories;
 using SFA.DAS.EAS.Domain.Interfaces;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Domain.Models.Levy;
 using SFA.DAS.NLog.Logger;
 
@@ -39,14 +39,14 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
                 new DasEnglishFraction
                 {
                     Id = "1",
-                    DateCalculated = DateTime.Parse(DateTime.Now.AddDays(-20).ToShortDateString()),
+                    DateCalculated = DateTime.Today.AddDays(-20),
                     EmpRef = _employerReference,
                     Amount = 0.45M
                 },
                 new DasEnglishFraction
                 {
                     Id = "2",
-                    DateCalculated = DateTime.Parse(DateTime.Now.AddDays(-10).ToShortDateString()),
+                    DateCalculated = DateTime.Today.AddDays(-10),
                     EmpRef = _employerReference,
                     Amount = 0.5M
                 }
@@ -56,7 +56,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
             {
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Now.AddDays(-20).ToShortDateString(),
+                    CalculatedAt = DateTime.Today.AddDays(-20),
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.45"}
@@ -64,7 +64,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
                 },
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Now.AddDays(-10).ToShortDateString(),
+                    CalculatedAt = DateTime.Today.AddDays(-10),
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.5"}
@@ -72,7 +72,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
                 },
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Now.AddDays(-5).ToShortDateString(),
+                    CalculatedAt = DateTime.Today.AddDays(-5),
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.55"}
@@ -80,7 +80,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
                 },
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Today.ToShortDateString(),
+                    CalculatedAt = DateTime.Today,
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.6"}
@@ -121,43 +121,6 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
             _englishFractionRepository.Verify(x => x.CreateEmployerFraction(
                 It.Is<DasEnglishFraction>(fraction => IsSameAsFractionCalculation(fraction, _fractionCalculations[2])),
                 _employerReference), Times.Once);
-
-            _englishFractionRepository.Verify(x => x.CreateEmployerFraction(
-               It.Is<DasEnglishFraction>(fraction => IsSameAsFractionCalculation(fraction, _fractionCalculations[3])),
-               _employerReference), Times.Once);
-        }
-
-        [Test]
-        public async Task ThenIShouldUpdateFractionsWithValidCalculatedDates()
-        {
-            //Assign
-            _fractionCalculations[2].CalculatedAt = "this is not a date";
-
-            _englishFractionRepository.Setup(
-                x => x.CreateEmployerFraction(It.IsAny<DasEnglishFraction>(), It.IsAny<string>()))
-                .Returns(Task.Run(() => { }));
-
-            _englishFractionRepository.Setup(x => x.GetAllEmployerFractions(_employerReference))
-                .ReturnsAsync(_existingFractions);
-
-            _hmrcService.Setup(x => x.GetEnglishFractions(_employerReference, It.IsAny<DateTime?>()))
-                .ReturnsAsync(new EnglishFractionDeclarations
-                {
-                    Empref = _employerReference,
-                    FractionCalculations = _fractionCalculations
-                });
-
-            //Act
-            await _handler.Handle(new UpdateEnglishFractionsCommand
-            {
-                EmployerReference = _employerReference,
-                EnglishFractionUpdateResponse = new GetEnglishFractionUpdateRequiredResponse { UpdateRequired = true }
-            });
-
-            //Assert
-            _englishFractionRepository.Verify(x => x.CreateEmployerFraction(
-                It.Is<DasEnglishFraction>(fraction => IsSameAsFractionCalculation(fraction, _fractionCalculations[2])),
-                _employerReference), Times.Never);
 
             _englishFractionRepository.Verify(x => x.CreateEmployerFraction(
                It.Is<DasEnglishFraction>(fraction => IsSameAsFractionCalculation(fraction, _fractionCalculations[3])),
@@ -215,7 +178,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
             {
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Now.AddDays(-20).ToShortDateString(),
+                    CalculatedAt = DateTime.Today.AddDays(-20),
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.45"}
@@ -223,7 +186,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
                 },
                 new FractionCalculation
                 {
-                    CalculatedAt = DateTime.Now.AddDays(-10).ToShortDateString(),
+                    CalculatedAt = DateTime.Today.AddDays(-10),
                     Fractions = new List<Fraction>
                     {
                         new Fraction {Region = "England", Value = "0.5"}
@@ -361,12 +324,12 @@ namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdateEnglishFractions
 
         private static bool IsSameAsFractionCalculation(DasEnglishFraction fraction, FractionCalculation fractionCalculation)
         {
-            var fractiondateString = fraction.DateCalculated.ToShortDateString();
+            var fractiondate = fraction.DateCalculated;
             var fractionAmountString = fraction.Amount.ToString(CultureInfo.InvariantCulture);
 
             var fractionCalculationAmount = fractionCalculation.Fractions.First().Value;
 
-            return fractiondateString.Equals(fractionCalculation.CalculatedAt) &&
+            return fractiondate.Equals(fractionCalculation.CalculatedAt) &&
                     fractionAmountString.Equals(fractionCalculationAmount);
         }
     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Commands/UpdatePayeInformationTests/WhenUpdatingPayeInformation.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Commands/UpdatePayeInformationTests/WhenUpdatingPayeInformation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using HMRC.ESFA.Levy.Api.Types;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.EAS.Application.Commands.UpdatePayeInformation;
@@ -7,7 +8,6 @@ using SFA.DAS.EAS.Application.Exceptions;
 using SFA.DAS.EAS.Application.Validation;
 using SFA.DAS.EAS.Domain.Data;
 using SFA.DAS.EAS.Domain.Interfaces;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Domain.Models.PAYE;
 
 namespace SFA.DAS.EAS.Application.UnitTests.Commands.UpdatePayeInformationTests

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetHmrcEmployerInformationTests/WhenRequestingEmployerInformation.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Queries/GetHmrcEmployerInformationTests/WhenRequestingEmployerInformation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
+using HMRC.ESFA.Levy.Api.Types;
 using MediatR;
 using Moq;
 using NUnit.Framework;
@@ -9,7 +10,6 @@ using SFA.DAS.EAS.Application.Queries.GetHmrcEmployerInformation;
 using SFA.DAS.EAS.Application.Queries.GetPayeSchemeInUse;
 using SFA.DAS.EAS.Application.Validation;
 using SFA.DAS.EAS.Domain.Interfaces;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Domain.Models.PAYE;
 using SFA.DAS.NLog.Logger;
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/SFA.DAS.EAS.Application.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/SFA.DAS.EAS.Application.UnitTests.csproj
@@ -60,6 +60,9 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="HtmlTags, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.6.0.0\lib\net45\HtmlTags.dll</HintPath>
     </Reference>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/packages.config
@@ -6,6 +6,7 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net45" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/UpdateEnglishFractions/UpdateEnglishFractionsCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/UpdateEnglishFractions/UpdateEnglishFractionsCommandHandler.cs
@@ -52,15 +52,6 @@ namespace SFA.DAS.EAS.Application.Commands.UpdateEnglishFractions
             var hmrcFractions = fractionCalculations.FractionCalculations.SelectMany(calculations =>
             {
                 var fractions = new List<DasEnglishFraction>();
-                DateTime dateCalculated;
-
-                if (!DateTime.TryParse(calculations.CalculatedAt, out dateCalculated))
-                {
-                    var exception = new ArgumentException($"Could not convert HMRC API calculatedAt value { calculations.CalculatedAt } to a datetime for english fraction update for EmpRef { message.EmployerReference}", nameof(calculations.CalculatedAt));
-                    _logger.Error(exception, exception.Message);
-
-                    return fractions;
-                }
 
                 foreach (var fraction in calculations.Fractions)
                 {
@@ -72,7 +63,7 @@ namespace SFA.DAS.EAS.Application.Commands.UpdateEnglishFractions
                             new DasEnglishFraction
                             {
                                 EmpRef = fractionCalculations.Empref,
-                                DateCalculated = DateTime.Parse(calculations.CalculatedAt),
+                                DateCalculated = calculations.CalculatedAt,
                                 Amount = decimal.Parse(fraction.Value)
                             });
                     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/DependencyResolution/ApprenticeshipLevyRegistry.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/DependencyResolution/ApprenticeshipLevyRegistry.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net.Http;
+using HMRC.ESFA.Levy.Api.Client;
+using SFA.DAS.EAS.Domain;
+using SFA.DAS.EAS.Domain.Configuration;
+using SFA.DAS.EAS.Infrastructure.DependencyResolution;
+using StructureMap;
+
+
+namespace SFA.DAS.EAS.Application.DependencyResolution
+{
+    public class ApprenticeshipLevyRegistry : Registry
+    {
+        public ApprenticeshipLevyRegistry()
+        {
+            var config = ConfigurationHelper.GetConfiguration<EmployerApprenticeshipsServiceConfiguration>(Constants.ServiceName);
+            var httpClient = new HttpClient {BaseAddress = new Uri(config.Hmrc.BaseUrl)};
+            For<IApprenticeshipLevyApiClient>().Use<ApprenticeshipLevyApiClient>().Ctor<HttpClient>().Is(httpClient);
+        }
+
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetHMRCLevyDeclaration/GetHMRCLevyDeclarationResponse.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetHMRCLevyDeclaration/GetHMRCLevyDeclarationResponse.cs
@@ -1,10 +1,11 @@
-﻿using SFA.DAS.EAS.Domain.Models.HmrcLevy;
+﻿using HMRC.ESFA.Levy.Api.Types;
 
 namespace SFA.DAS.EAS.Application.Queries.GetHMRCLevyDeclaration
 {
     public class GetHMRCLevyDeclarationResponse
     {
         public LevyDeclarations LevyDeclarations { get; set; }
+
         public string Empref { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetHmrcEmployerInformation/GetHmrcEmployerInformationResponse.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/GetHmrcEmployerInformation/GetHmrcEmployerInformationResponse.cs
@@ -4,7 +4,7 @@ namespace SFA.DAS.EAS.Application.Queries.GetHmrcEmployerInformation
 {
     public class GetHmrcEmployerInformationResponse
     {
-        public EmpRefLevyInformation EmployerLevyInformation { get; set; }
+        public HMRC.ESFA.Levy.Api.Types.EmpRefLevyInformation EmployerLevyInformation { get; set; }
         public string Empref { get; set; }
         public bool EmprefNotFound { get; set; }
     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
@@ -50,6 +50,12 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Client">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Client.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="HtmlTags, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.6.0.0\lib\net45\HtmlTags.dll</HintPath>
     </Reference>
@@ -281,6 +287,7 @@
     <Compile Include="Commands\CreateTransferTransactions\CreateTransferTransactionsCommand.cs" />
     <Compile Include="Commands\CreateTransferTransactions\CreateTransferTransactionsCommandHandler.cs" />
     <Compile Include="Commands\CreateTransferTransactions\CreateTransferTransactionsCommandValidator.cs" />
+    <Compile Include="DependencyResolution\ApprenticeshipLevyRegistry.cs" />
     <Compile Include="DependencyResolution\AuditRegistry.cs" />
     <Compile Include="DependencyResolution\AuthorizationRegistry.cs" />
     <Compile Include="DependencyResolution\CachesRegistry.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/packages.config
@@ -6,6 +6,7 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IHmrcService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Interfaces/IHmrcService.cs
@@ -9,14 +9,14 @@ namespace SFA.DAS.EAS.Domain.Interfaces
         string GenerateAuthRedirectUrl(string redirectUrl);
 
         Task<HmrcTokenResponse> GetAuthenticationToken(string redirectUrl, string accessCode);
-        Task<EmpRefLevyInformation> GetEmprefInformation(string authToken, string empRef);
+        Task<HMRC.ESFA.Levy.Api.Types.EmpRefLevyInformation> GetEmprefInformation(string authToken, string empRef);
         Task<string> DiscoverEmpref(string authToken);
-        Task<LevyDeclarations> GetLevyDeclarations(string empRef);
-        Task<EnglishFractionDeclarations> GetEnglishFractions(string empRef);
+        Task<HMRC.ESFA.Levy.Api.Types.LevyDeclarations> GetLevyDeclarations(string empRef);
+        Task<HMRC.ESFA.Levy.Api.Types.EnglishFractionDeclarations> GetEnglishFractions(string empRef);
         Task<DateTime> GetLastEnglishFractionUpdate();
         Task<string> GetOgdAccessToken();
-        Task<LevyDeclarations> GetLevyDeclarations(string empRef,DateTime? fromDate);
-        Task<EnglishFractionDeclarations> GetEnglishFractions(string empRef, DateTime? fromDate);
-        Task<EmpRefLevyInformation> GetEmprefInformation(string empRef);
+        Task<HMRC.ESFA.Levy.Api.Types.LevyDeclarations> GetLevyDeclarations(string empRef,DateTime? fromDate);
+        Task<HMRC.ESFA.Levy.Api.Types.EnglishFractionDeclarations> GetEnglishFractions(string empRef, DateTime? fromDate);
+        Task<HMRC.ESFA.Levy.Api.Types.EmpRefLevyInformation> GetEmprefInformation(string empRef);
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EAS.Domain.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using HMRC.ESFA.Levy.Api.Types.Exceptions;
 using Polly;
 using SFA.DAS.EAS.Domain.Http;
 using SFA.DAS.NLog.Logger;
@@ -35,10 +36,15 @@ namespace SFA.DAS.EAS.Infrastructure.ExecutionPolicies
                 return default(T);
             }
 
-            if (ex is HMRC.ESFA.Levy.Api.Types.Exceptions.ApiHttpException)
+            if (ex is ApiHttpException exception)
             {
                 _logger.Info($"ApiHttpException - {ex.Message}");
-                return default(T);
+
+                switch (exception.HttpCode)
+                {
+                    case 404:
+                        return default(T);
+                }
             }
 
             _logger.Error(ex, $"Exceeded retry limit - {ex.Message}");

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/ExecutionPolicies/HmrcExecutionPolicy.cs
@@ -35,6 +35,12 @@ namespace SFA.DAS.EAS.Infrastructure.ExecutionPolicies
                 return default(T);
             }
 
+            if (ex is HMRC.ESFA.Levy.Api.Types.Exceptions.ApiHttpException)
+            {
+                _logger.Info($"ApiHttpException - {ex.Message}");
+                return default(T);
+            }
+
             _logger.Error(ex, $"Exceeded retry limit - {ex.Message}");
             throw ex;
         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
@@ -65,6 +65,12 @@
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Client, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Client.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="MediatR, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MediatR.2.1.0\lib\net45\MediatR.dll</HintPath>
       <Private>True</Private>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/packages.config
@@ -10,6 +10,8 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
   <package id="FastMember.Signed" version="1.1.0" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Client" version="1.0.43" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/ObjectMothers/DeclarationsObjectMother.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/ObjectMothers/DeclarationsObjectMother.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
+using HMRC.ESFA.Levy.Api.Types;
 
 namespace SFA.DAS.EAS.TestCommon.ObjectMothers
 {
@@ -16,7 +16,7 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                         new Declaration
                         {
                             PayrollPeriod = new PayrollPeriod {Month = 10, Year = "2016"},
-                            SubmissionTime = DateTime.UtcNow.ToString(),
+                            SubmissionTime = DateTime.UtcNow,
                             DateCeased = DateTime.UtcNow,
                             NoPaymentForPeriod = true
                         }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/SFA.DAS.EAS.TestCommon.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/SFA.DAS.EAS.TestCommon.csproj
@@ -67,6 +67,9 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="HtmlTags, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.6.0.0\lib\net45\HtmlTags.dll</HintPath>
     </Reference>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/packages.config
@@ -10,6 +10,7 @@
   <package id="FluentAssertions" version="4.17.0" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net45" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net462" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerAccountPayeOrchestratorTests/WhenAddingAPayeScheme.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerAccountPayeOrchestratorTests/WhenAddingAPayeScheme.cs
@@ -20,6 +20,9 @@ using SFA.DAS.EAS.Domain.Models.UserProfile;
 using SFA.DAS.EAS.Web.Orchestrators;
 using SFA.DAS.EAS.Web.ViewModels;
 using SFA.DAS.NLog.Logger;
+using Employer = HMRC.ESFA.Levy.Api.Types.Employer;
+using EmpRefLevyInformation = HMRC.ESFA.Levy.Api.Types.EmpRefLevyInformation;
+using Name = HMRC.ESFA.Levy.Api.Types.Name;
 
 namespace SFA.DAS.EAS.Web.UnitTests.Orchestrators.EmployerAccountPayeOrchestratorTests
 {

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/HmrcOrchestratorTests/WhenCallingHmrcService.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/HmrcOrchestratorTests/WhenCallingHmrcService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using HMRC.ESFA.Levy.Api.Types;
 using MediatR;
 using Moq;
 using NUnit.Framework;
@@ -8,7 +9,6 @@ using SFA.DAS.EAS.Application.Queries.GetHmrcEmployerInformation;
 using SFA.DAS.EAS.Domain.Configuration;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.Account;
-using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Web.Orchestrators;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.HashingService;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
@@ -63,6 +63,9 @@
     <Reference Include="Hashids.net, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="HtmlTags, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.6.0.0\lib\net45\HtmlTags.dll</HintPath>
     </Reference>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/packages.config
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/packages.config
@@ -7,6 +7,7 @@
   <package id="FluentAssertions" version="4.17.0" targetFramework="net45" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net45" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net45" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/Providers/LevyDeclaration.cs
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/Providers/LevyDeclaration.cs
@@ -168,7 +168,7 @@ namespace SFA.DAS.EAS.LevyDeclarationProvider.Worker.Providers
 
                 var dasDeclaration = new DasDeclaration
                 {
-                    SubmissionDate = DateTime.Parse(declaration.SubmissionTime),
+                    SubmissionDate = declaration.SubmissionTime,
                     Id = declaration.Id,
                     PayrollMonth = declaration.PayrollPeriod?.Month,
                     PayrollYear = declaration.PayrollPeriod?.Year,

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/SFA.DAS.EAS.LevyDeclarationProvider.Worker.csproj
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/SFA.DAS.EAS.LevyDeclarationProvider.Worker.csproj
@@ -46,6 +46,12 @@
       <HintPath>..\packages\Hashids.net.1.2.2\lib\net45\Hashids.net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Client, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Client.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="HMRC.ESFA.Levy.Api.Types, Version=1.0.43.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HMRC.ESFA.Levy.Api.Types.1.0.43\lib\net452\HMRC.ESFA.Levy.Api.Types.dll</HintPath>
+    </Reference>
     <Reference Include="MediatR, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MediatR.2.1.0\lib\net45\MediatR.dll</HintPath>
       <Private>True</Private>

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
@@ -49,6 +49,8 @@ namespace SFA.DAS.EAS.LevyDeclarationProvider.Worker
 
             _container = new Container(c =>
             {
+                c.AddRegistry<ApprenticeshipLevyRegistry>();
+                c.AddRegistry<ConfigurationRegistry>();
                 c.AddRegistry<ConfigurationRegistry>();
                 c.AddRegistry<EventsRegistry>();
                 c.AddRegistry<ExecutionPoliciesRegistry>();
@@ -75,8 +77,8 @@ namespace SFA.DAS.EAS.LevyDeclarationProvider.Worker
         {
             Trace.TraceInformation("SFA.DAS.LevyDeclarationProvider.Worker is stopping");
 
-            this._cancellationTokenSource.Cancel();
-            this._runCompleteEvent.WaitOne();
+            _cancellationTokenSource.Cancel();
+            _runCompleteEvent.WaitOne();
 
             base.OnStop();
 

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/packages.config
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/packages.config
@@ -4,6 +4,8 @@
   <package id="AutoMapper" version="5.1.1" targetFramework="net462" />
   <package id="AzureTableStorageNLogTarget" version="1.0.9" targetFramework="net462" />
   <package id="Hashids.net" version="1.2.2" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Client" version="1.0.43" targetFramework="net462" />
+  <package id="HMRC.ESFA.Levy.Api.Types" version="1.0.43" targetFramework="net462" />
   <package id="MediatR" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />


### PR DESCRIPTION
This PR updates the HMRC service to use the Levy API nuget package instead of direct service calls. 

It removes a couple of redundant (checking url) tests and refactors others to use the new API. 

It adds the common types into some other projects. 

I have left the calls to the API wrapped in poly (in the same location where there was a direct service call).

We need to test the website and the web jobs are all still functional.
