### PR TITLE
Revert trans download excel processor to use General Long Time Pattern

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/ExcelTransactionFormatterTests/WhenICreateAExcelFile.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application.UnitTests/Formatters/Transactions/ExcelTransactionFormatterTests/WhenICreateAExcelFile.cs
@@ -57,7 +57,7 @@ namespace SFA.DAS.EAS.Application.UnitTests.Formatters.Transactions.ExcelTransac
                 },
                 new[]
                 {
-                    _transactionLine.DateCreated.ToString("dd/MM/yyyy"), _transactionLine.TransactionType,
+                    _transactionLine.DateCreated.ToString(), _transactionLine.TransactionType,
                     _transactionLine.PayeScheme, _transactionLine.PeriodEnd, _transactionLine.LevyDeclaredFormatted,
                     _transactionLine.EnglishFractionFormatted, _transactionLine.TenPercentTopUpFormatted,
                     _transactionLine.TrainingProvider, _transactionLine.Uln,

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/ExcelTransactionFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Formatters/TransactionDowloads/ExcelTransactionFormatter.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.EAS.Application.Formatters.TransactionDowloads
 
             excelRows.AddRange(transactions.Select(transaction => new[]
             {
-                transaction.DateCreated.ToString("dd/MM/yyyy"),
+                transaction.DateCreated.ToString("G"),
                 transaction.TransactionType,
                 transaction.PayeScheme,
                 transaction.PeriodEnd,


### PR DESCRIPTION
Had to revert the Excel Formatter to use the system long date format as it was originally.