### PR TITLE
AML-2153 Optimised GetAccountStats sproc

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Account.Database/StoredProcedures/GetAccountStats.sql
+++ b/src/SFA.DAS.EAS.Employer_Account.Database/StoredProcedures/GetAccountStats.sql
@@ -1,13 +1,8 @@
 ﻿CREATE PROCEDURE [employer_account].[GetAccountStats]
 	@accountId BIGINT = 0	
 AS
-	SELECT	MAX(acc.Id) as AccountId,
-			COUNT(DISTINCT his.Id) as PayeSchemeCount, 
-			COUNT(DISTINCT ag.Id) as OrganisationCount, 
-			COUNT(DISTINCT mem.UserId) as TeamMemberCount 
-	FROM [employer_account].[Account] acc
-	INNER JOIN [employer_account].[AccountHistory] his ON acc.Id = his.AccountId
-	INNER JOIN [employer_account].[EmployerAgreement] ag ON acc.Id = ag.AccountId
-	INNER JOIN [employer_account].[Membership] mem ON acc.id = mem.AccountId
-	WHERE acc.Id = @accountId
-	GROUP BY acc.Id
+	SELECT
+		(SELECT @accountId) AS AccountId,
+		(SELECT COUNT(1) FROM [employer_account].[AccountHistory] WHERE AccountId = @accountId) AS PayeSchemeCount,
+		(SELECT COUNT(1) FROM [employer_account].[EmployerAgreement] WHERE AccountId = @accountId) AS OrganisationCount,
+		(SELECT COUNT(1) FROM [employer_account].[Membership] WHERE AccountId = @accountId) AS TeamMemberCount


### PR DESCRIPTION
After looking at the execution plan in the production environment the query was spending most of its time performing distinct sorts for each inner join. This is expensive when running against accounts with a lot of Organisations & PAYE schemes associated with them. We've just removed the inner joins and in turn the need for the `DISTINCT` calls.