### PR TITLE
AML-2155 Store NoPayment Property, Remove no Payments from the Views

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/SeedData.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/SeedData.sql
@@ -21,7 +21,7 @@ BEGIN
 	DECLARE @submissionDate DATETIME
 	SET @submissionDate = GETDATE()
 
-	EXEC [employer_financial].[CreateDeclaration] @levyAmount, @payeScheme, @submissionDate, 123, 123, @accountId, @levyAmount, ''17-18'', 1, @submissionDate, NULL, NULL, NULL, 0, 0 
+	EXEC [employer_financial].[CreateDeclaration] @levyAmount, @payeScheme, @submissionDate, 123, 123, @accountId, @levyAmount, ''17-18'', 1, @submissionDate, NULL, NULL, NULL, 0, 0, 0
 END'
 
 EXEC sp_executesql @sqlCommand

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/CreateDeclaration.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/CreateDeclaration.sql
@@ -13,7 +13,8 @@
 	@InactiveFrom DATETIME = NULL,
 	@InactiveTo DATETIME = NULL,
 	@EndOfYearAdjustment BIT,
-	@EndOfYearAdjustmentAmount DECIMAL(18,4)
+	@EndOfYearAdjustmentAmount DECIMAL(18,4),
+	@NoPaymentForPeriod BIT
 AS
 	
 
@@ -33,7 +34,8 @@ INSERT INTO [employer_financial].[LevyDeclaration]
 		DateCeased,
 		InactiveFrom,
 		InactiveTo,
-		HmrcSubmissionId
+		HmrcSubmissionId,
+		NoPaymentForPeriod
 	) 
 VALUES 
 	(
@@ -51,5 +53,6 @@ VALUES
 		@DateCeased,
 		@InactiveFrom,
 		@InactiveTo,
-		@HmrcSubmissionId
+		@HmrcSubmissionId,
+		@NoPaymentForPeriod
 	);

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
@@ -15,7 +15,8 @@
 	[DateCeased] DATETIME NULL,
 	[InactiveFrom] DATETIME NULL,
 	[InactiveTo] DATETIME NULL,
-	[HmrcSubmissionId] BIGINT NULL
+	[HmrcSubmissionId] BIGINT NULL,
+	[NoPaymentForPeriod] BIT DEFAULT 0
 )
 
 GO

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/DasLevyRepository.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Data/DasLevyRepository.cs
@@ -101,6 +101,8 @@ namespace SFA.DAS.EAS.Infrastructure.Data
                             parameters.Add("@EndOfYearAdjustmentAmount", dasDeclaration.EndOfYearAdjustmentAmount,
                                 DbType.Decimal);
 
+                            parameters.Add("@NoPaymentForPeriod", dasDeclaration.NoPaymentForPeriod, DbType.Boolean);
+
                             await unitOfWork.Execute("[employer_financial].[CreateDeclaration]", parameters,
                                 CommandType.StoredProcedure);
                         }


### PR DESCRIPTION
In this PR we store the NoPaymentForPeriod flag on any LevyDeclarations, if this flag is set we do not include this LevyDeclaration in the GetLevyDeclarationview. The GetLevyDeclaration is used to calculate the actual Levy declared that month from the current YTD.