### PR TITLE
AML-2187 Seed TransactionLineTypes and PaymentTransactionTypes tables

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/SeedProdData.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/SeedData/SeedProdData.sql
@@ -19,3 +19,22 @@ BEGIN
 	VALUES
 	('2015-01-01 00:00:00.000',0.1)
 END 
+
+IF (NOT EXISTS(SELECT TransactionType FROM [employer_financial].[TransactionLineTypes] WHERE TransactionType = 1))
+BEGIN
+	INSERT [employer_financial].[TransactionLineTypes] ([TransactionType], [Description]) VALUES (1, N'Levy')
+END
+IF (NOT EXISTS(SELECT TransactionType FROM [employer_financial].[TransactionLineTypes] WHERE TransactionType = 2))
+BEGIN
+	INSERT [employer_financial].[TransactionLineTypes] ([TransactionType], [Description]) VALUES (2, N'Levy Adjustment')
+END
+
+
+IF (NOT EXISTS(SELECT TransactionType FROM [employer_financial].[PaymentTransactionTypes] WHERE TransactionType = 1))
+BEGIN
+	INSERT [employer_financial].[PaymentTransactionTypes] ([TransactionType], [Description]) VALUES (N'1', N'Monthly Payment')
+END
+IF (NOT EXISTS(SELECT TransactionType FROM [employer_financial].[PaymentTransactionTypes] WHERE TransactionType = 2))
+BEGIN
+	INSERT [employer_financial].[PaymentTransactionTypes] ([TransactionType], [Description]) VALUES (N'2', N'Completion Payment')
+END


### PR DESCRIPTION
The  TransactionLineTypes and PaymentTransactionTypes tables are not being populated in production. This PR should add the relevant values if they don't exist.

What scripts get run in AT and Test environments etc, that are different to those in Prod?
