### PR TITLE
AML-2226 Transaction Download incorrectly aggregating apprentice payments.

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -57,7 +57,7 @@ AND DateCreated < @ToDate
 
 
 
--- We will use this View to get payments that relate to transaction lines and are funding source 1,2,3
+-- We will use this Common Table Expression to get payments that relate to transaction lines and are funding source 1,2,3
 ;WITH AllFunds (DateCreated, AccountId, Ukprn, Uln, PeriodEnd, PaymentId, FundingSource, Amount, PaymentMetaDataId, TransactionTypeDesc,
 	TrainingProvider,
 	Apprentice,
@@ -65,7 +65,6 @@ AND DateCreated < @ToDate
 	ApprenticeTrainingCourseLevel)
 AS
 (
---	SELECT PaymentId, FundingSource, Amount, p.AccountId, p.Ukprn, p.Uln, p.PeriodEnd, p.PaymentMetaDataId
 	SELECT 
 			transLine.DateCreated,
 			p.AccountId, 

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -125,42 +125,42 @@ INSERT INTO #output
 
 -- Join the Views together
 SELECT DISTINCT 
-	COALESCE(MAX(accountFunds1.DateCreated),MAX(accountFunds2.DateCreated),MAX(accountFunds3.DateCreated)) AS DateCreated,
-	COALESCE(MAX(accountFunds1.TransactionTypeDesc),MAX(accountFunds2.TransactionTypeDesc),MAX(accountFunds3.TransactionTypeDesc)) AS [Description],
-	COALESCE(MAX(accountFunds1.TrainingProvider),MAX(accountFunds2.TrainingProvider),MAX(accountFunds3.TrainingProvider)) AS TrainingProvider,
+	COALESCE(MAX(fundsPaidFromLevy.DateCreated),MAX(fundsGovermentContribution.DateCreated),MAX(fundsEmployerContribution.DateCreated)) AS DateCreated,
+	COALESCE(MAX(fundsPaidFromLevy.TransactionTypeDesc),MAX(fundsGovermentContribution.TransactionTypeDesc),MAX(fundsEmployerContribution.TransactionTypeDesc)) AS [Description],
+	COALESCE(MAX(fundsPaidFromLevy.TrainingProvider),MAX(fundsGovermentContribution.TrainingProvider),MAX(fundsEmployerContribution.TrainingProvider)) AS TrainingProvider,
 	uniquePayments.Uln AS Uln, 
-	COALESCE(MAX(accountFunds1.Apprentice),MAX(accountFunds2.Apprentice),MAX(accountFunds3.Apprentice)) AS Apprentice,
-	COALESCE(MAX(accountFunds1.ApprenticeTrainingCourse), MAX(accountFunds2.ApprenticeTrainingCourse), MAX(accountFunds3.ApprenticeTrainingCourse)) AS ApprenticeTrainingCourse,
-	COALESCE(MAX(accountFunds1.ApprenticeTrainingCourseLevel), MAX(accountFunds2.ApprenticeTrainingCourseLevel), MAX(accountFunds3.ApprenticeTrainingCourseLevel)) AS ApprenticeTrainingCourseLevel,
-	COALESCE((SUM(accountFunds1.[Amount]) * -1), 0) AS PaidFromLevy,
-	COALESCE((SUM(accountFunds3.Amount) * -1), 0) AS EmployerContribution,
-	COALESCE((SUM(accountFunds2.Amount) * -1), 0) AS GovermentContribution,
-	COALESCE((SUM(accountFunds1.[Amount]) * -1),0) + COALESCE((SUM(accountFunds2.[Amount]) * -1),0) + COALESCE((SUM(accountFunds3.[Amount]) * -1),0) AS Total
+	COALESCE(MAX(fundsPaidFromLevy.Apprentice),MAX(fundsGovermentContribution.Apprentice),MAX(fundsEmployerContribution.Apprentice)) AS Apprentice,
+	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourse), MAX(fundsGovermentContribution.ApprenticeTrainingCourse), MAX(fundsEmployerContribution.ApprenticeTrainingCourse)) AS ApprenticeTrainingCourse,
+	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourseLevel), MAX(fundsGovermentContribution.ApprenticeTrainingCourseLevel), MAX(fundsEmployerContribution.ApprenticeTrainingCourseLevel)) AS ApprenticeTrainingCourseLevel,
+	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1), 0) AS PaidFromLevy,
+	COALESCE((SUM(fundsEmployerContribution.Amount) * -1), 0) AS EmployerContribution,
+	COALESCE((SUM(fundsGovermentContribution.Amount) * -1), 0) AS GovermentContribution,
+	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1),0) + COALESCE((SUM(fundsGovermentContribution.[Amount]) * -1),0) + COALESCE((SUM(fundsEmployerContribution.[Amount]) * -1),0) AS Total
 FROM UniqueApprenticePaymentRecords uniquePayments
-LEFT JOIN AllFunds accountFunds1 
-	ON accountFunds1.AccountId = uniquePayments.AccountId 
-		AND accountFunds1.Ukprn = uniquePayments.Ukprn 
-		AND accountFunds1.Uln = uniquePayments.Uln
-		AND accountFunds1.PeriodEnd = uniquePayments.PeriodEnd
-		AND accountFunds1.FundingSource = 1
-LEFT JOIN AllFunds accountFunds2 
-	ON accountFunds2.AccountId = uniquePayments.AccountId 
-		AND accountFunds2.Ukprn = uniquePayments.Ukprn 
-		AND accountFunds2.Uln = uniquePayments.Uln
-		AND accountFunds2.PeriodEnd = uniquePayments.PeriodEnd
-		AND accountFunds2.FundingSource = 2
-LEFT JOIN AllFunds accountFunds3
-	ON accountFunds3.AccountId = uniquePayments.AccountId 
-		AND accountFunds3.Ukprn = uniquePayments.Ukprn 
-		AND accountFunds3.Uln = uniquePayments.Uln
-		AND accountFunds3.PeriodEnd = uniquePayments.PeriodEnd
-		AND accountFunds3.FundingSource = 3
+LEFT JOIN AllFunds fundsPaidFromLevy 
+	ON fundsPaidFromLevy.AccountId = uniquePayments.AccountId 
+		AND fundsPaidFromLevy.Ukprn = uniquePayments.Ukprn 
+		AND fundsPaidFromLevy.Uln = uniquePayments.Uln
+		AND fundsPaidFromLevy.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsPaidFromLevy.FundingSource = 1
+LEFT JOIN AllFunds fundsGovermentContribution 
+	ON fundsGovermentContribution.AccountId = uniquePayments.AccountId 
+		AND fundsGovermentContribution.Ukprn = uniquePayments.Ukprn 
+		AND fundsGovermentContribution.Uln = uniquePayments.Uln
+		AND fundsGovermentContribution.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsGovermentContribution.FundingSource = 2
+LEFT JOIN AllFunds fundsEmployerContribution
+	ON fundsEmployerContribution.AccountId = uniquePayments.AccountId 
+		AND fundsEmployerContribution.Ukprn = uniquePayments.Ukprn 
+		AND fundsEmployerContribution.Uln = uniquePayments.Uln
+		AND fundsEmployerContribution.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsEmployerContribution.FundingSource = 3
 GROUP BY uniquePayments.AccountId, 
 	uniquePayments.Ukprn, 
 	uniquePayments.Uln, 
 	uniquePayments.PeriodEnd
 HAVING
-	MAX(accountFunds1.[Amount]) > 0 OR MAX(accountFunds2.[Amount]) > 0 OR MAX(accountFunds3.[Amount]) > 0
+	MAX(fundsPaidFromLevy.[Amount]) > 0 OR MAX(fundsGovermentContribution.[Amount]) > 0 OR MAX(fundsEmployerContribution.[Amount]) > 0
 
 SELECT * FROM #output
 

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -42,8 +42,8 @@ SELECT DateCreated,
 	tl.EmpRef,
 	ld.PayrollYear,
 	ld.PayrollMonth,
-	LevyDeclared,
-	EnglishFraction,
+	tl.LevyDeclared,
+	tl.EnglishFraction,
 	tl.Amount - (LevyDeclared * EnglishFraction) AS TenPercentTopUp,
 	tl.Amount
 FROM [employer_financial].TransactionLine tl
@@ -71,9 +71,9 @@ AS
 			p.Ukprn, 
 			p.Uln, 
 			p.PeriodEnd, 
-			PaymentId, 
-			FundingSource, 
-			Amount, 
+			p.PaymentId, 
+			p.FundingSource, 
+			p.Amount, 
 			p.PaymentMetaDataId, 
 			ptt.[Description] AS TransactionTypeDesc,
 			meta.ProviderName AS TrainingProvider,
@@ -93,8 +93,8 @@ AS
 		INNER JOIN [employer_financial].[PaymentMetaData] meta 
 			ON p.PaymentMetaDataId = meta.Id
 	WHERE  p.AccountId = @AccountId
-		AND DateCreated >= @FromDate 
-		AND DateCreated <= @ToDate
+		AND transLine.DateCreated >= @FromDate 
+		AND transLine.DateCreated <= @ToDate
 		AND p.FundingSource in (1,2,3)
 )
 , UniqueApprenticePaymentRecords -- This gets all the unique Account, Provider, Learner, PeriodEnd combinations

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -42,8 +42,8 @@ SELECT DateCreated,
 	tl.EmpRef,
 	ld.PayrollYear,
 	ld.PayrollMonth,
-	tl.LevyDeclared,
-	tl.EnglishFraction,
+	LevyDeclared,
+	EnglishFraction,
 	tl.Amount - (LevyDeclared * EnglishFraction) AS TenPercentTopUp,
 	tl.Amount
 FROM [employer_financial].TransactionLine tl
@@ -57,7 +57,7 @@ AND DateCreated < @ToDate
 
 
 
--- We will use this Common Table Expression to get payments that relate to transaction lines and are funding source 1,2,3
+-- We will use this View to get payments that relate to transaction lines and are funding source 1,2,3
 ;WITH AllFunds (DateCreated, AccountId, Ukprn, Uln, PeriodEnd, PaymentId, FundingSource, Amount, PaymentMetaDataId, TransactionTypeDesc,
 	TrainingProvider,
 	Apprentice,
@@ -65,15 +65,16 @@ AND DateCreated < @ToDate
 	ApprenticeTrainingCourseLevel)
 AS
 (
+--	SELECT PaymentId, FundingSource, Amount, p.AccountId, p.Ukprn, p.Uln, p.PeriodEnd, p.PaymentMetaDataId
 	SELECT 
 			transLine.DateCreated,
 			p.AccountId, 
 			p.Ukprn, 
 			p.Uln, 
 			p.PeriodEnd, 
-			p.PaymentId, 
-			p.FundingSource, 
-			p.Amount, 
+			PaymentId, 
+			FundingSource, 
+			Amount, 
 			p.PaymentMetaDataId, 
 			ptt.[Description] AS TransactionTypeDesc,
 			meta.ProviderName AS TrainingProvider,
@@ -81,7 +82,10 @@ AS
 			meta.ApprenticeshipCourseName AS ApprenticeTrainingCourse,
 			meta.ApprenticeshipCourseLevel AS ApprenticeTrainingCourseLevel
 	from [employer_financial].[Payment]   p
-		INNER JOIN  employer_financial.TransactionLine transLine
+		INNER JOIN (SELECT PeriodEnd,AccountId,ukprn, EmpRef, TransactionDate, DateCreated, LevyDeclared, EnglishFraction 
+					FROM employer_financial.TransactionLine 
+					WHERE DateCreated >= @FromDate AND 
+						DateCreated <= @ToDate) transLine 
 			ON transLine.AccountId = p.AccountId 
 				AND transLine.PeriodEnd = p.PeriodEnd 
 				AND transLine.Ukprn = p.Ukprn
@@ -90,8 +94,8 @@ AS
 		INNER JOIN [employer_financial].[PaymentMetaData] meta 
 			ON p.PaymentMetaDataId = meta.Id
 	WHERE  p.AccountId = @AccountId
-		AND transLine.DateCreated >= @FromDate 
-		AND transLine.DateCreated <= @ToDate
+		AND DateCreated >= @FromDate 
+		AND DateCreated <= @ToDate
 		AND p.FundingSource in (1,2,3)
 )
 , UniqueApprenticePaymentRecords -- This gets all the unique Account, Provider, Learner, PeriodEnd combinations
@@ -122,42 +126,42 @@ INSERT INTO #output
 
 -- Join the Views together
 SELECT DISTINCT 
-	COALESCE(MAX(fundsPaidFromLevy.DateCreated),MAX(fundsGovermentContribution.DateCreated),MAX(fundsEmployerContribution.DateCreated)) AS DateCreated,
-	COALESCE(MAX(fundsPaidFromLevy.TransactionTypeDesc),MAX(fundsGovermentContribution.TransactionTypeDesc),MAX(fundsEmployerContribution.TransactionTypeDesc)) AS [Description],
-	COALESCE(MAX(fundsPaidFromLevy.TrainingProvider),MAX(fundsGovermentContribution.TrainingProvider),MAX(fundsEmployerContribution.TrainingProvider)) AS TrainingProvider,
+	COALESCE(MAX(accountFunds1.DateCreated),MAX(accountFunds2.DateCreated),MAX(accountFunds3.DateCreated)) AS DateCreated,
+	COALESCE(MAX(accountFunds1.TransactionTypeDesc),MAX(accountFunds2.TransactionTypeDesc),MAX(accountFunds3.TransactionTypeDesc)) AS [Description],
+	COALESCE(MAX(accountFunds1.TrainingProvider),MAX(accountFunds2.TrainingProvider),MAX(accountFunds3.TrainingProvider)) AS TrainingProvider,
 	uniquePayments.Uln AS Uln, 
-	COALESCE(MAX(fundsPaidFromLevy.Apprentice),MAX(fundsGovermentContribution.Apprentice),MAX(fundsEmployerContribution.Apprentice)) AS Apprentice,
-	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourse), MAX(fundsGovermentContribution.ApprenticeTrainingCourse), MAX(fundsEmployerContribution.ApprenticeTrainingCourse)) AS ApprenticeTrainingCourse,
-	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourseLevel), MAX(fundsGovermentContribution.ApprenticeTrainingCourseLevel), MAX(fundsEmployerContribution.ApprenticeTrainingCourseLevel)) AS ApprenticeTrainingCourseLevel,
-	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1), 0) AS PaidFromLevy,
-	COALESCE((SUM(fundsEmployerContribution.Amount) * -1), 0) AS EmployerContribution,
-	COALESCE((SUM(fundsGovermentContribution.Amount) * -1), 0) AS GovermentContribution,
-	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1),0) + COALESCE((SUM(fundsGovermentContribution.[Amount]) * -1),0) + COALESCE((SUM(fundsEmployerContribution.[Amount]) * -1),0) AS Total
+	COALESCE(MAX(accountFunds1.Apprentice),MAX(accountFunds2.Apprentice),MAX(accountFunds3.Apprentice)) AS Apprentice,
+	COALESCE(MAX(accountFunds1.ApprenticeTrainingCourse), MAX(accountFunds2.ApprenticeTrainingCourse), MAX(accountFunds3.ApprenticeTrainingCourse)) AS ApprenticeTrainingCourse,
+	COALESCE(MAX(accountFunds1.ApprenticeTrainingCourseLevel), MAX(accountFunds2.ApprenticeTrainingCourseLevel), MAX(accountFunds3.ApprenticeTrainingCourseLevel)) AS ApprenticeTrainingCourseLevel,
+	COALESCE((SUM(accountFunds1.[Amount]) * -1), 0) AS PaidFromLevy,
+	COALESCE((SUM(accountFunds3.Amount) * -1), 0) AS EmployerContribution,
+	COALESCE((SUM(accountFunds2.Amount) * -1), 0) AS GovermentContribution,
+	COALESCE((SUM(accountFunds1.[Amount]) * -1),0) + COALESCE((SUM(accountFunds2.[Amount]) * -1),0) + COALESCE((SUM(accountFunds3.[Amount]) * -1),0) AS Total
 FROM UniqueApprenticePaymentRecords uniquePayments
-LEFT JOIN AllFunds fundsPaidFromLevy 
-	ON fundsPaidFromLevy.AccountId = uniquePayments.AccountId 
-		AND fundsPaidFromLevy.Ukprn = uniquePayments.Ukprn 
-		AND fundsPaidFromLevy.Uln = uniquePayments.Uln
-		AND fundsPaidFromLevy.PeriodEnd = uniquePayments.PeriodEnd
-		AND fundsPaidFromLevy.FundingSource = 1
-LEFT JOIN AllFunds fundsGovermentContribution 
-	ON fundsGovermentContribution.AccountId = uniquePayments.AccountId 
-		AND fundsGovermentContribution.Ukprn = uniquePayments.Ukprn 
-		AND fundsGovermentContribution.Uln = uniquePayments.Uln
-		AND fundsGovermentContribution.PeriodEnd = uniquePayments.PeriodEnd
-		AND fundsGovermentContribution.FundingSource = 2
-LEFT JOIN AllFunds fundsEmployerContribution
-	ON fundsEmployerContribution.AccountId = uniquePayments.AccountId 
-		AND fundsEmployerContribution.Ukprn = uniquePayments.Ukprn 
-		AND fundsEmployerContribution.Uln = uniquePayments.Uln
-		AND fundsEmployerContribution.PeriodEnd = uniquePayments.PeriodEnd
-		AND fundsEmployerContribution.FundingSource = 3
+LEFT JOIN AllFunds accountFunds1 
+	ON accountFunds1.AccountId = uniquePayments.AccountId 
+		AND accountFunds1.Ukprn = uniquePayments.Ukprn 
+		AND accountFunds1.Uln = uniquePayments.Uln
+		AND accountFunds1.PeriodEnd = uniquePayments.PeriodEnd
+		AND accountFunds1.FundingSource = 1
+LEFT JOIN AllFunds accountFunds2 
+	ON accountFunds2.AccountId = uniquePayments.AccountId 
+		AND accountFunds2.Ukprn = uniquePayments.Ukprn 
+		AND accountFunds2.Uln = uniquePayments.Uln
+		AND accountFunds2.PeriodEnd = uniquePayments.PeriodEnd
+		AND accountFunds2.FundingSource = 2
+LEFT JOIN AllFunds accountFunds3
+	ON accountFunds3.AccountId = uniquePayments.AccountId 
+		AND accountFunds3.Ukprn = uniquePayments.Ukprn 
+		AND accountFunds3.Uln = uniquePayments.Uln
+		AND accountFunds3.PeriodEnd = uniquePayments.PeriodEnd
+		AND accountFunds3.FundingSource = 3
 GROUP BY uniquePayments.AccountId, 
 	uniquePayments.Ukprn, 
 	uniquePayments.Uln, 
 	uniquePayments.PeriodEnd
 HAVING
-	MAX(fundsPaidFromLevy.[Amount]) > 0 OR MAX(fundsGovermentContribution.[Amount]) > 0 OR MAX(fundsEmployerContribution.[Amount]) > 0
+	MAX(accountFunds1.[Amount]) > 0 OR MAX(accountFunds2.[Amount]) > 0 OR MAX(accountFunds3.[Amount]) > 0
 
 SELECT * FROM #output
 

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -81,10 +81,7 @@ AS
 			meta.ApprenticeshipCourseName AS ApprenticeTrainingCourse,
 			meta.ApprenticeshipCourseLevel AS ApprenticeTrainingCourseLevel
 	from [employer_financial].[Payment]   p
-		INNER JOIN (SELECT PeriodEnd,AccountId,ukprn, EmpRef, TransactionDate, DateCreated, LevyDeclared, EnglishFraction 
-					FROM employer_financial.TransactionLine 
-					WHERE DateCreated >= @FromDate AND 
-						DateCreated <= @ToDate) transLine 
+		INNER JOIN  employer_financial.TransactionLine transLine
 			ON transLine.AccountId = p.AccountId 
 				AND transLine.PeriodEnd = p.PeriodEnd 
 				AND transLine.Ukprn = p.Ukprn

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetAllTransactionDetailsForAccountByDate.sql
@@ -42,18 +42,67 @@ SELECT DateCreated,
 	tl.EmpRef,
 	ld.PayrollYear,
 	ld.PayrollMonth,
-	LevyDeclared,
-	EnglishFraction,
+	tl.LevyDeclared,
+	tl.EnglishFraction,
 	tl.Amount - (LevyDeclared * EnglishFraction) AS TenPercentTopUp,
 	tl.Amount
 FROM [employer_financial].TransactionLine tl
 LEFT JOIN [employer_financial].[TransactionLineTypes] tlt ON tlt.TransactionType = IIF(Amount >= 0, 1, 2)
 INNER JOIN [employer_financial].LevyDeclarationTopup ldt ON ldt.SubmissionId = tl.SubmissionId
 INNER JOIN [employer_financial].LevyDeclaration ld ON ld.SubmissionId = tl.SubmissionId
-WHERE tl.AccountId = @AccountId 
+WHERE tl.AccountId = @accountId 
 AND tl.TransactionType IN (1, 2) 
 AND DateCreated >= @FromDate 
 AND DateCreated < @ToDate
+
+
+
+-- We will use this Common Table Expression to get payments that relate to transaction lines and are funding source 1,2,3
+;WITH AllFunds (DateCreated, AccountId, Ukprn, Uln, PeriodEnd, PaymentId, FundingSource, Amount, PaymentMetaDataId, TransactionTypeDesc,
+	TrainingProvider,
+	Apprentice,
+	ApprenticeTrainingCourse,
+	ApprenticeTrainingCourseLevel)
+AS
+(
+	SELECT 
+			transLine.DateCreated,
+			p.AccountId, 
+			p.Ukprn, 
+			p.Uln, 
+			p.PeriodEnd, 
+			p.PaymentId, 
+			p.FundingSource, 
+			p.Amount, 
+			p.PaymentMetaDataId, 
+			ptt.[Description] AS TransactionTypeDesc,
+			meta.ProviderName AS TrainingProvider,
+			meta.ApprenticeName AS Apprentice,
+			meta.ApprenticeshipCourseName AS ApprenticeTrainingCourse,
+			meta.ApprenticeshipCourseLevel AS ApprenticeTrainingCourseLevel
+	from [employer_financial].[Payment]   p
+		INNER JOIN  employer_financial.TransactionLine transLine
+			ON transLine.AccountId = p.AccountId 
+				AND transLine.PeriodEnd = p.PeriodEnd 
+				AND transLine.Ukprn = p.Ukprn
+		INNER JOIN [employer_financial].[PaymentTransactionTypes] ptt 
+			ON ptt.TransactionType =  p.TransactionType
+		INNER JOIN [employer_financial].[PaymentMetaData] meta 
+			ON p.PaymentMetaDataId = meta.Id
+	WHERE  p.AccountId = @AccountId
+		AND transLine.DateCreated >= @FromDate 
+		AND transLine.DateCreated <= @ToDate
+		AND p.FundingSource in (1,2,3)
+)
+, UniqueApprenticePaymentRecords -- This gets all the unique Account, Provider, Learner, PeriodEnd combinations
+AS
+(
+SELECT AccountId, Ukprn, Uln, PeriodEnd 
+	FROM [employer_financial].[Payment]   p
+		WHERE  p.AccountId = @AccountId
+			AND p.FundingSource in (1,2,3)
+	GROUP BY AccountId, Ukprn, Uln, PeriodEnd
+)
 
 
 INSERT INTO #output
@@ -70,51 +119,45 @@ INSERT INTO #output
 	GovermentContribution,
 	Total
 )
-SELECT MAX(transLine.DateCreated) AS DateCreated,
-	ptt.[Description],
-	meta.ProviderName AS TrainingProvider,
-	p.Uln AS Uln,
-	meta.ApprenticeName AS Apprentice,
-	meta.ApprenticeshipCourseName AS ApprenticeTrainingCourse,
-	meta.ApprenticeshipCourseLevel AS ApprenticeTrainingCourseLevel,
-	COALESCE((SUM(pays1.[Amount]) * -1), 0) AS PaidFromLevy,
-	COALESCE((SUM(pays3.Amount) * -1), 0) AS EmployerContribution,
-	COALESCE((SUM(pays2.Amount) * -1), 0) AS GovermentContribution,
-	COALESCE((SUM(pays1.[Amount]) * -1),0) + COALESCE((SUM(pays2.[Amount]) * -1),0) + COALESCE((SUM(pays3.[Amount]) * -1),0) AS Total
 
-FROM [employer_financial].[Payment] p
-  INNER JOIN [employer_financial].[PaymentTransactionTypes] ptt ON ptt.TransactionType =  p.TransactionType
-  INNER JOIN [employer_financial].[PaymentMetaData] meta ON p.PaymentMetaDataId = meta.Id
-  INNER JOIN (SELECT PeriodEnd,AccountId,Ukprn, EmpRef, TransactionDate, DateCreated, LevyDeclared, EnglishFraction FROM employer_financial.TransactionLine WHERE DateCreated >= @FromDate AND 
-        DateCreated <= @ToDate) transLine ON transLine.AccountId = p.AccountId AND transLine.PeriodEnd = p.PeriodEnd AND transLine.Ukprn = p.Ukprn
-  LEFT JOIN [employer_financial].[Payment] pays1 
-	ON pays1.AccountId = p.AccountId 
-		AND pays1.Ukprn = p.Ukprn 
-		AND pays1.FundingSource = 1 
-		AND pays1.PaymentMetaDataId = meta.Id
-  LEFT JOIN [employer_financial].[Payment] pays2 
-	ON pays2.AccountId = p.AccountId 
-	AND pays2.Ukprn = p.Ukprn 
-	AND pays2.FundingSource = 2 
-	AND pays2.PaymentMetaDataId = meta.Id
-  LEFT JOIN [employer_financial].[Payment] pays3 
-	ON pays3.AccountId = p.AccountId 
-	AND pays3.Ukprn = p.Ukprn 
-	AND pays3.FundingSource = 3 
-	AND pays3.PaymentMetaDataId = meta.Id
-  WHERE 
-	  p.AccountId = @AccountId AND
-	  p.FundingSource IN (1,2,3)  
-  GROUP BY p.AccountId, 
-	  p.Ukprn, 
-	  p.TransactionType, 
-	  ptt.[Description],
-	  p.Uln, 
-	  meta.ProviderName, 
-	  meta.ApprenticeshipCourseName, 
-	  meta.ApprenticeshipCourseLevel, 
-	  meta.PathwayName, 
-	  meta.ApprenticeName
+-- Join the Views together
+SELECT DISTINCT 
+	COALESCE(MAX(fundsPaidFromLevy.DateCreated),MAX(fundsGovermentContribution.DateCreated),MAX(fundsEmployerContribution.DateCreated)) AS DateCreated,
+	COALESCE(MAX(fundsPaidFromLevy.TransactionTypeDesc),MAX(fundsGovermentContribution.TransactionTypeDesc),MAX(fundsEmployerContribution.TransactionTypeDesc)) AS [Description],
+	COALESCE(MAX(fundsPaidFromLevy.TrainingProvider),MAX(fundsGovermentContribution.TrainingProvider),MAX(fundsEmployerContribution.TrainingProvider)) AS TrainingProvider,
+	uniquePayments.Uln AS Uln, 
+	COALESCE(MAX(fundsPaidFromLevy.Apprentice),MAX(fundsGovermentContribution.Apprentice),MAX(fundsEmployerContribution.Apprentice)) AS Apprentice,
+	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourse), MAX(fundsGovermentContribution.ApprenticeTrainingCourse), MAX(fundsEmployerContribution.ApprenticeTrainingCourse)) AS ApprenticeTrainingCourse,
+	COALESCE(MAX(fundsPaidFromLevy.ApprenticeTrainingCourseLevel), MAX(fundsGovermentContribution.ApprenticeTrainingCourseLevel), MAX(fundsEmployerContribution.ApprenticeTrainingCourseLevel)) AS ApprenticeTrainingCourseLevel,
+	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1), 0) AS PaidFromLevy,
+	COALESCE((SUM(fundsEmployerContribution.Amount) * -1), 0) AS EmployerContribution,
+	COALESCE((SUM(fundsGovermentContribution.Amount) * -1), 0) AS GovermentContribution,
+	COALESCE((SUM(fundsPaidFromLevy.[Amount]) * -1),0) + COALESCE((SUM(fundsGovermentContribution.[Amount]) * -1),0) + COALESCE((SUM(fundsEmployerContribution.[Amount]) * -1),0) AS Total
+FROM UniqueApprenticePaymentRecords uniquePayments
+LEFT JOIN AllFunds fundsPaidFromLevy 
+	ON fundsPaidFromLevy.AccountId = uniquePayments.AccountId 
+		AND fundsPaidFromLevy.Ukprn = uniquePayments.Ukprn 
+		AND fundsPaidFromLevy.Uln = uniquePayments.Uln
+		AND fundsPaidFromLevy.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsPaidFromLevy.FundingSource = 1
+LEFT JOIN AllFunds fundsGovermentContribution 
+	ON fundsGovermentContribution.AccountId = uniquePayments.AccountId 
+		AND fundsGovermentContribution.Ukprn = uniquePayments.Ukprn 
+		AND fundsGovermentContribution.Uln = uniquePayments.Uln
+		AND fundsGovermentContribution.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsGovermentContribution.FundingSource = 2
+LEFT JOIN AllFunds fundsEmployerContribution
+	ON fundsEmployerContribution.AccountId = uniquePayments.AccountId 
+		AND fundsEmployerContribution.Ukprn = uniquePayments.Ukprn 
+		AND fundsEmployerContribution.Uln = uniquePayments.Uln
+		AND fundsEmployerContribution.PeriodEnd = uniquePayments.PeriodEnd
+		AND fundsEmployerContribution.FundingSource = 3
+GROUP BY uniquePayments.AccountId, 
+	uniquePayments.Ukprn, 
+	uniquePayments.Uln, 
+	uniquePayments.PeriodEnd
+HAVING
+	MAX(fundsPaidFromLevy.[Amount]) > 0 OR MAX(fundsGovermentContribution.[Amount]) > 0 OR MAX(fundsEmployerContribution.[Amount]) > 0
 
 SELECT * FROM #output
 


### PR DESCRIPTION
…cts payments in a different way.

Previously we were getting apprentice payments aggregated together. This PR changes the stored procedure, to use a couple of temporary views to store all the payments for an account between the date ranges. We then join to these views, the 3 different fund types are joined as 3 queries as I need a column for each fund type.

Performance: In Production this query took about 1s for the accounts I tried.

We ran this query against some accounts with known Transaction download issues and the data looked OK. The payments were no longer aggregating.