### PR TITLE
AML-2242 AML-2409 Add breakdown of levy by date rather than one per month

### DIFF
--- a/src/SFA.DAS.EAS.Web/Orchestrators/EmployerAccountTransactionsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/EmployerAccountTransactionsOrchestrator.cs
@@ -18,438 +18,436 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using SFA.DAS.Activities.Client;
+using TransactionLine = SFA.DAS.EAS.Domain.Models.Transaction.TransactionLine;
 
 namespace SFA.DAS.EAS.Web.Orchestrators
 {
-    public class EmployerAccountTransactionsOrchestrator
-    {
-        private readonly ICurrentDateTime _currentTime;
-        private readonly ILog _logger;
-        private readonly IMediator _mediator;
+	public class EmployerAccountTransactionsOrchestrator
+	{
+		private readonly ICurrentDateTime _currentTime;
+		private readonly ILog _logger;
+		private readonly IMediator _mediator;
 
-        protected EmployerAccountTransactionsOrchestrator()
-        {
+		protected EmployerAccountTransactionsOrchestrator()
+		{
 
-        }
+		}
 
-        public EmployerAccountTransactionsOrchestrator(IMediator mediator, ICurrentDateTime currentTime, ILog logger)
-        {
-            _mediator = mediator;
-            _currentTime = currentTime;
-            _logger = logger;
-        }
+		public EmployerAccountTransactionsOrchestrator(IMediator mediator, ICurrentDateTime currentTime, ILog logger)
+		{
+			_mediator = mediator;
+			_currentTime = currentTime;
+			_logger = logger;
+		}
 
-        public async Task<OrchestratorResponse<TransactionLineViewModel<LevyDeclarationTransactionLine>>>
-            FindAccountLevyDeclarationTransactions(
-                string hashedId, DateTime fromDate, DateTime toDate, string externalUserId)
-        {
-            var data = await _mediator.SendAsync(new FindEmployerAccountLevyDeclarationTransactionsQuery
-            {
-                HashedAccountId = hashedId,
-                FromDate = fromDate,
-                ToDate = toDate,
-                ExternalUserId = externalUserId
-            });
+		public async Task<OrchestratorResponse<TransactionLineViewModel<LevyDeclarationTransactionLine>>>
+			FindAccountLevyDeclarationTransactions(
+				string hashedId, DateTime fromDate, DateTime toDate, string externalUserId)
+		{
+			var data = await _mediator.SendAsync(new FindEmployerAccountLevyDeclarationTransactionsQuery
+			{
+				HashedAccountId = hashedId,
+				FromDate = fromDate,
+				ToDate = toDate,
+				ExternalUserId = externalUserId
+			});
 
-            foreach (var transaction in data.Transactions)
-            {
-                var payeSchemeData = await _mediator.SendAsync(new GetPayeSchemeByRefQuery
-                {
-                    HashedAccountId = hashedId,
-                    Ref = transaction.EmpRef
-                });
+			foreach (var transaction in data.Transactions)
+			{
+				var payeSchemeData = await _mediator.SendAsync(new GetPayeSchemeByRefQuery
+				{
+					HashedAccountId = hashedId,
+					Ref = transaction.EmpRef
+				});
 
-                transaction.PayeSchemeName = payeSchemeData?.PayeScheme?.Name ?? string.Empty;
-            }
+				transaction.PayeSchemeName = payeSchemeData?.PayeScheme?.Name ?? string.Empty;
+			}
 
-            return new OrchestratorResponse<TransactionLineViewModel<LevyDeclarationTransactionLine>>
-            {
-                Status = HttpStatusCode.OK,
-                Data = new TransactionLineViewModel<LevyDeclarationTransactionLine>
-                {
-                    Amount = data.Total,
-                    SubTransactions = data.Transactions,
-                    TransactionDate = data.Transactions.First().DateCreated
-                }
-            };
-        }
+			return new OrchestratorResponse<TransactionLineViewModel<LevyDeclarationTransactionLine>>
+			{
+				Status = HttpStatusCode.OK,
+				Data = new TransactionLineViewModel<LevyDeclarationTransactionLine>
+				{
+					Amount = data.Total,
+					SubTransactions = data.Transactions,
+					TransactionDate = data.Transactions.First().DateCreated
+				}
+			};
+		}
 
-        public async Task<OrchestratorResponse<ProviderPaymentsSummaryViewModel>> GetProviderPaymentSummary(
-            string hashedId, long ukprn, DateTime fromDate, DateTime toDate, string externalUserId)
-        {
-            try
-            {
-                var data = await _mediator.SendAsync(new FindAccountProviderPaymentsQuery
-                {
-                    HashedAccountId = hashedId,
-                    UkPrn = ukprn,
-                    FromDate = fromDate,
-                    ToDate = toDate,
-                    ExternalUserId = externalUserId,
-                });
+		public async Task<OrchestratorResponse<ProviderPaymentsSummaryViewModel>> GetProviderPaymentSummary(
+			string hashedId, long ukprn, DateTime fromDate, DateTime toDate, string externalUserId)
+		{
+			try
+			{
+				var data = await _mediator.SendAsync(new FindAccountProviderPaymentsQuery
+				{
+					HashedAccountId = hashedId,
+					UkPrn = ukprn,
+					FromDate = fromDate,
+					ToDate = toDate,
+					ExternalUserId = externalUserId,
+				});
 
-                var courseGroups = data.Transactions.GroupBy(x => new { x.CourseName, x.CourseLevel, x.PathwayName, x.CourseStartDate });
+				var courseGroups =
+					data.Transactions.GroupBy(x => new {x.CourseName, x.CourseLevel, x.PathwayName, x.CourseStartDate});
 
-                var coursePaymentSummaries = courseGroups.Select(x =>
-                {
-                    var levyPayments = x.Where(p => p.TransactionType == TransactionItemType.Payment).ToList();
+				var coursePaymentSummaries = courseGroups.Select(x =>
+				{
+					var levyPayments = x.Where(p => p.TransactionType == TransactionItemType.Payment).ToList();
 
-                    return new CoursePaymentSummaryViewModel
-                    {
-                        CourseName = x.Key.CourseName,
-                        CourseLevel = x.Key.CourseLevel,
-                        PathwayName = x.Key.PathwayName,
-                        PathwayCode = levyPayments.Max(p => p.PathwayCode),
-                        CourseStartDate = x.Key.CourseStartDate,
-                        LevyPaymentAmount = levyPayments.Sum(p => p.LineAmount),
-                        EmployerCoInvestmentAmount = levyPayments.Sum(p => p.EmployerCoInvestmentAmount),
-                        SFACoInvestmentAmount = levyPayments.Sum(p => p.SfaCoInvestmentAmount)
-                    };
-                }).ToList();
+					return new CoursePaymentSummaryViewModel
+					{
+						CourseName = x.Key.CourseName,
+						CourseLevel = x.Key.CourseLevel,
+						PathwayName = x.Key.PathwayName,
+						PathwayCode = levyPayments.Max(p => p.PathwayCode),
+						CourseStartDate = x.Key.CourseStartDate,
+						LevyPaymentAmount = levyPayments.Sum(p => p.LineAmount),
+						EmployerCoInvestmentAmount = levyPayments.Sum(p => p.EmployerCoInvestmentAmount),
+						SFACoInvestmentAmount = levyPayments.Sum(p => p.SfaCoInvestmentAmount)
+					};
+				}).ToList();
 
-                return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
-                {
-                    Status = HttpStatusCode.OK,
-                    Data = new ProviderPaymentsSummaryViewModel
-                    {
-                        HashedAccountId = hashedId,
-                        UkPrn = ukprn,
-                        ProviderName = data.ProviderName,
-                        PaymentDate = data.DateCreated,
-                        FromDate = fromDate,
-                        ToDate = toDate,
-                        CoursePayments = coursePaymentSummaries,
-                        LevyPaymentsTotal = coursePaymentSummaries.Sum(p => p.LevyPaymentAmount),
-                        SFACoInvestmentsTotal = coursePaymentSummaries.Sum(p => p.SFACoInvestmentAmount),
-                        EmployerCoInvestmentsTotal = coursePaymentSummaries.Sum(p => p.EmployerCoInvestmentAmount),
-                        PaymentsTotal = coursePaymentSummaries.Sum(p => p.TotalAmount)
-                    }
-                };
-            }
-            catch (NotFoundException e)
-            {
-                return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
-                {
-                    Status = HttpStatusCode.NotFound,
-                    Exception = e
-                };
-            }
-            catch (InvalidRequestException e)
-            {
-                return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
-                {
-                    Status = HttpStatusCode.BadRequest,
-                    Exception = e
-                };
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
-                {
-                    Status = HttpStatusCode.Unauthorized,
-                    Exception = e
-                };
-            }
-        }
+				return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
+				{
+					Status = HttpStatusCode.OK,
+					Data = new ProviderPaymentsSummaryViewModel
+					{
+						HashedAccountId = hashedId,
+						UkPrn = ukprn,
+						ProviderName = data.ProviderName,
+						PaymentDate = data.DateCreated,
+						FromDate = fromDate,
+						ToDate = toDate,
+						CoursePayments = coursePaymentSummaries,
+						LevyPaymentsTotal = coursePaymentSummaries.Sum(p => p.LevyPaymentAmount),
+						SFACoInvestmentsTotal = coursePaymentSummaries.Sum(p => p.SFACoInvestmentAmount),
+						EmployerCoInvestmentsTotal = coursePaymentSummaries.Sum(p => p.EmployerCoInvestmentAmount),
+						PaymentsTotal = coursePaymentSummaries.Sum(p => p.TotalAmount)
+					}
+				};
+			}
+			catch (NotFoundException e)
+			{
+				return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
+				{
+					Status = HttpStatusCode.NotFound,
+					Exception = e
+				};
+			}
+			catch (InvalidRequestException e)
+			{
+				return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
+				{
+					Status = HttpStatusCode.BadRequest,
+					Exception = e
+				};
+			}
+			catch (UnauthorizedAccessException e)
+			{
+				return new OrchestratorResponse<ProviderPaymentsSummaryViewModel>
+				{
+					Status = HttpStatusCode.Unauthorized,
+					Exception = e
+				};
+			}
+		}
 
-        public async Task<OrchestratorResponse<PaymentTransactionViewModel>> FindAccountPaymentTransactions(
-            string hashedId, long ukprn, DateTime fromDate, DateTime toDate, string externalUserId)
-        {
-            try
-            {
-                var data = await _mediator.SendAsync(new FindAccountProviderPaymentsQuery
-                {
-                    HashedAccountId = hashedId,
-                    UkPrn = ukprn,
-                    FromDate = fromDate,
-                    ToDate = toDate,
-                    ExternalUserId = externalUserId
-                });
+		public async Task<OrchestratorResponse<PaymentTransactionViewModel>> FindAccountPaymentTransactions(
+			string hashedId, long ukprn, DateTime fromDate, DateTime toDate, string externalUserId)
+		{
+			try
+			{
+				var data = await _mediator.SendAsync(new FindAccountProviderPaymentsQuery
+				{
+					HashedAccountId = hashedId,
+					UkPrn = ukprn,
+					FromDate = fromDate,
+					ToDate = toDate,
+					ExternalUserId = externalUserId
+				});
 
-                var courseGroups = data.Transactions.GroupBy(x => new { x.CourseName, x.CourseLevel, x.CourseStartDate });
+				var courseGroups = data.Transactions.GroupBy(x => new {x.CourseName, x.CourseLevel, x.CourseStartDate});
 
-                var coursePaymentGroups = courseGroups.Select(x => new ApprenticeshipPaymentGroup
-                {
-                    ApprenticeCourseName = x.Key.CourseName,
-                    CourseLevel = x.Key.CourseLevel,
-                    CourseStartDate = x.Key.CourseStartDate,
-                    Payments = x.ToList()
-                }).ToList();
-
-
-                return new OrchestratorResponse<PaymentTransactionViewModel>
-                {
-                    Status = HttpStatusCode.OK,
-                    Data = new PaymentTransactionViewModel
-                    {
-                        ProviderName = data.ProviderName,
-                        TransactionDate = data.TransactionDate,
-                        Amount = data.Total,
-                        SubTransactions = data.Transactions,
-                        CoursePaymentGroups = coursePaymentGroups
-                    }
-                };
-            }
-            catch (NotFoundException e)
-            {
-                return new OrchestratorResponse<PaymentTransactionViewModel>
-                {
-                    Status = HttpStatusCode.NotFound,
-                    Exception = e
-                };
-            }
-            catch (InvalidRequestException e)
-            {
-                return new OrchestratorResponse<PaymentTransactionViewModel>
-                {
-                    Status = HttpStatusCode.BadRequest,
-                    Exception = e
-                };
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                return new OrchestratorResponse<PaymentTransactionViewModel>
-                {
-                    Status = HttpStatusCode.Unauthorized,
-                    Exception = e
-                };
-            }
-        }
-
-        public virtual async Task<OrchestratorResponse<FinanceDashboardViewModel>> GetFinanceDashboardViewModel(
-            string hashedId, int year, int month, string externalUserId)
-        {
-            var employerAccountResult = await _mediator.SendAsync(new GetEmployerAccountHashedQuery
-            {
-                HashedAccountId = hashedId,
-                UserId = externalUserId
-            });
-
-            if (employerAccountResult.Account == null)
-            {
-                return new OrchestratorResponse<FinanceDashboardViewModel>
-                {
-                    Data = new FinanceDashboardViewModel()
-                };
-            }
-            employerAccountResult.Account.HashedId = hashedId;
-
-            var data =
-                await
-                    _mediator.SendAsync(new GetEmployerAccountTransactionsQuery
-                    {
-                        ExternalUserId = externalUserId,
-                        Year = year,
-                        Month = month,
-                        HashedAccountId = hashedId
-                    });
-            var latestLineItem = data?.Data?.TransactionLines?.FirstOrDefault();
-
-            var currentBalance = latestLineItem?.Balance ?? 0;
-
-            return new OrchestratorResponse<FinanceDashboardViewModel>
-            {
-                Data = new FinanceDashboardViewModel
-                {
-                    Account = employerAccountResult.Account,
-                    CurrentLevyFunds = currentBalance
-                }
-            };
-        }
+				var coursePaymentGroups = courseGroups.Select(x => new ApprenticeshipPaymentGroup
+				{
+					ApprenticeCourseName = x.Key.CourseName,
+					CourseLevel = x.Key.CourseLevel,
+					CourseStartDate = x.Key.CourseStartDate,
+					Payments = x.ToList()
+				}).ToList();
 
 
-        public virtual async Task<OrchestratorResponse<TransactionViewResultViewModel>> GetAccountTransactions(string hashedId, int year, int month, string externalUserId)
-        {
-            var employerAccountResult = await _mediator.SendAsync(new GetEmployerAccountHashedQuery
-            {
-                HashedAccountId = hashedId,
-                UserId = externalUserId
-            });
+				return new OrchestratorResponse<PaymentTransactionViewModel>
+				{
+					Status = HttpStatusCode.OK,
+					Data = new PaymentTransactionViewModel
+					{
+						ProviderName = data.ProviderName,
+						TransactionDate = data.TransactionDate,
+						Amount = data.Total,
+						SubTransactions = data.Transactions,
+						CoursePaymentGroups = coursePaymentGroups
+					}
+				};
+			}
+			catch (NotFoundException e)
+			{
+				return new OrchestratorResponse<PaymentTransactionViewModel>
+				{
+					Status = HttpStatusCode.NotFound,
+					Exception = e
+				};
+			}
+			catch (InvalidRequestException e)
+			{
+				return new OrchestratorResponse<PaymentTransactionViewModel>
+				{
+					Status = HttpStatusCode.BadRequest,
+					Exception = e
+				};
+			}
+			catch (UnauthorizedAccessException e)
+			{
+				return new OrchestratorResponse<PaymentTransactionViewModel>
+				{
+					Status = HttpStatusCode.Unauthorized,
+					Exception = e
+				};
+			}
+		}
 
-            if (employerAccountResult.Account == null)
-            {
-                return new OrchestratorResponse<TransactionViewResultViewModel> { Data = new TransactionViewResultViewModel(_currentTime.Now) };
-            }
+		public virtual async Task<OrchestratorResponse<FinanceDashboardViewModel>> GetFinanceDashboardViewModel(
+			string hashedId, int year, int month, string externalUserId)
+		{
+			var employerAccountResult = await _mediator.SendAsync(new GetEmployerAccountHashedQuery
+			{
+				HashedAccountId = hashedId,
+				UserId = externalUserId
+			});
 
-            var data =
-                await
-                    _mediator.SendAsync(new GetEmployerAccountTransactionsQuery
-                    {
-                        ExternalUserId = externalUserId,
-                        Year = year,
-                        Month = month,
-                        HashedAccountId = hashedId
-                    });
-            var latestLineItem = data.Data.TransactionLines.FirstOrDefault();
-            decimal currentBalance;
-            DateTime currentBalanceCalcultedOn;
+			if (employerAccountResult.Account == null)
+			{
+				return new OrchestratorResponse<FinanceDashboardViewModel>
+				{
+					Data = new FinanceDashboardViewModel()
+				};
+			}
 
-            if (latestLineItem != null)
-            {
-                currentBalance = latestLineItem.Balance;
-                currentBalanceCalcultedOn = latestLineItem.TransactionDate;
-            }
-            else
-            {
-                currentBalance = 0;
-                currentBalanceCalcultedOn = DateTime.Today;
-            }
+			employerAccountResult.Account.HashedId = hashedId;
 
-            data.Data.TransactionLines = AggregateLevyTransactions(data.Data.TransactionLines);
-
-            return new OrchestratorResponse<TransactionViewResultViewModel>
-            {
-                Data = new TransactionViewResultViewModel(_currentTime.Now)
-                {
-                    Account = employerAccountResult.Account,
-                    Model = new TransactionViewModel
-                    {
-                        CurrentBalance = currentBalance,
-                        CurrentBalanceCalcultedOn = currentBalanceCalcultedOn,
-                        Data = data.Data
-                    },
-                    Month = data.Month,
-                    Year = data.Year,
-                    AccountHasPreviousTransactions = data.AccountHasPreviousTransactions
-                }
-            };
-        }
+			var data =
+				await
+					_mediator.SendAsync(new GetEmployerAccountTransactionsQuery
+					{
+						ExternalUserId = externalUserId,
+						Year = year,
+						Month = month,
+						HashedAccountId = hashedId
+					});
 
 
-        public virtual async Task<OrchestratorResponse<CoursePaymentDetailsViewModel>> GetCoursePaymentSummary(
+			var latestLineItem = data?.Data?.TransactionLines?.FirstOrDefault();
+
+			var currentBalance = latestLineItem?.Balance ?? 0;
+
+			return new OrchestratorResponse<FinanceDashboardViewModel>
+			{
+				Data = new FinanceDashboardViewModel
+				{
+					Account = employerAccountResult.Account,
+					CurrentLevyFunds = currentBalance
+				}
+			};
+		}
+
+
+		public virtual async Task<OrchestratorResponse<TransactionViewResultViewModel>> GetAccountTransactions(
+			string hashedId, int year, int month, string externalUserId)
+		{
+			var employerAccountResult = await _mediator.SendAsync(new GetEmployerAccountHashedQuery
+			{
+				HashedAccountId = hashedId,
+				UserId = externalUserId
+			});
+
+			if (employerAccountResult.Account == null)
+			{
+				return new OrchestratorResponse<TransactionViewResultViewModel>
+				{
+					Data = new TransactionViewResultViewModel(_currentTime.Now)
+				};
+			}
+
+			var aggregratedTransactions =
+				await
+					_mediator.SendAsync(new GetEmployerAccountTransactionsQuery
+					{
+						ExternalUserId = externalUserId,
+						Year = year,
+						Month = month,
+						HashedAccountId = hashedId
+					});
+
+			var viewModel = BuildTransactionViewModel(aggregratedTransactions.Data, year, month);
+
+			return new OrchestratorResponse<TransactionViewResultViewModel>
+			{
+				Data = new TransactionViewResultViewModel(_currentTime.Now)
+				{
+					Account = employerAccountResult.Account,
+					Model = viewModel,
+					Month = aggregratedTransactions.Month,
+					Year = aggregratedTransactions.Year,
+					AccountHasPreviousTransactions = aggregratedTransactions.AccountHasPreviousTransactions
+				}
+			};
+		}
+
+		public virtual async Task<OrchestratorResponse<CoursePaymentDetailsViewModel>> GetCoursePaymentSummary(
             string hashedAccountId, long ukprn, string courseName, int? courseLevel, int? pathwayCode,
-            DateTime fromDate, DateTime toDate, string externalUserId)
-        {
-            try
-            {
-                var data = await _mediator.SendAsync(new FindAccountCoursePaymentsQuery
-                {
-                    HashedAccountId = hashedAccountId,
-                    UkPrn = ukprn,
-                    CourseName = courseName,
-                    CourseLevel = courseLevel,
-                    PathwayCode = pathwayCode,
-                    FromDate = fromDate,
-                    ToDate = toDate,
-                    ExternalUserId = externalUserId
-                });
+			DateTime fromDate, DateTime toDate, string externalUserId)
+		{
+			try
+			{
+				var data = await _mediator.SendAsync(new FindAccountCoursePaymentsQuery
+				{
+					HashedAccountId = hashedAccountId,
+					UkPrn = ukprn,
+					CourseName = courseName,
+					CourseLevel = courseLevel,
+					PathwayCode = pathwayCode,
+					FromDate = fromDate,
+					ToDate = toDate,
+					ExternalUserId = externalUserId
+				});
 
-                var apprenticePaymentGroups = data.Transactions.GroupBy(x => new { x.ApprenticeName, x.ApprenticeNINumber });
+				var apprenticePaymentGroups = data.Transactions.GroupBy(x => new {x.ApprenticeName, x.ApprenticeNINumber});
 
-                var paymentSummaries = apprenticePaymentGroups.Select(pg =>
-                {
-                    var payments = pg.Where(x => x.TransactionType == TransactionItemType.Payment).ToList();
+				var paymentSummaries = apprenticePaymentGroups.Select(pg =>
+				{
+					var payments = pg.Where(x => x.TransactionType == TransactionItemType.Payment).ToList();
 
-                    return new AprrenticeshipPaymentSummaryViewModel
-                    {
-                        ApprenticeName = pg.Key.ApprenticeName,
-                        LevyPaymentAmount = payments.Sum(t => t.LineAmount),
-                        SFACoInvestmentAmount = payments.Sum(p => p.SfaCoInvestmentAmount),
-                        EmployerCoInvestmentAmount = payments.Sum(p => p.EmployerCoInvestmentAmount)
-                    };
-                });
+					return new AprrenticeshipPaymentSummaryViewModel
+					{
+						ApprenticeName = pg.Key.ApprenticeName,
+						LevyPaymentAmount = payments.Sum(t => t.LineAmount),
+						SFACoInvestmentAmount = payments.Sum(p => p.SfaCoInvestmentAmount),
+						EmployerCoInvestmentAmount = payments.Sum(p => p.EmployerCoInvestmentAmount)
+					};
+				});
 
-                var apprenticePayments = paymentSummaries.ToList();
+				var apprenticePayments = paymentSummaries.ToList();
 
-                return new OrchestratorResponse<CoursePaymentDetailsViewModel>
-                {
-                    Status = HttpStatusCode.OK,
-                    Data = new CoursePaymentDetailsViewModel
-                    {
-                        ProviderName = data.ProviderName,
-                        CourseName = data.CourseName,
-                        CourseLevel = data.CourseLevel,
-                        PathwayName = data.PathwayName,
-                        PaymentDate = data.DateCreated,
-                        LevyPaymentsTotal = apprenticePayments.Sum(p => p.LevyPaymentAmount),
-                        SFACoInvestmentTotal = apprenticePayments.Sum(p => p.SFACoInvestmentAmount),
-                        EmployerCoInvestmentTotal = apprenticePayments.Sum(p => p.EmployerCoInvestmentAmount),
-                        ApprenticePayments = apprenticePayments
-                    }
-                };
-            }
-            catch (NotFoundException e)
-            {
-                return new OrchestratorResponse<CoursePaymentDetailsViewModel>
-                {
-                    Status = HttpStatusCode.NotFound,
-                    Exception = e
-                };
-            }
-            catch (InvalidRequestException e)
-            {
-                return new OrchestratorResponse<CoursePaymentDetailsViewModel>
-                {
-                    Status = HttpStatusCode.BadRequest,
-                    Exception = e
-                };
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                return new OrchestratorResponse<CoursePaymentDetailsViewModel>
-                {
-                    Status = HttpStatusCode.Unauthorized,
-                    Exception = e
-                };
-            }
-        }
+				return new OrchestratorResponse<CoursePaymentDetailsViewModel>
+				{
+					Status = HttpStatusCode.OK,
+					Data = new CoursePaymentDetailsViewModel
+					{
+						ProviderName = data.ProviderName,
+						CourseName = data.CourseName,
+						CourseLevel = data.CourseLevel,
+						PathwayName = data.PathwayName,
+						PaymentDate = data.DateCreated,
+						LevyPaymentsTotal = apprenticePayments.Sum(p => p.LevyPaymentAmount),
+						SFACoInvestmentTotal = apprenticePayments.Sum(p => p.SFACoInvestmentAmount),
+						EmployerCoInvestmentTotal = apprenticePayments.Sum(p => p.EmployerCoInvestmentAmount),
+						ApprenticePayments = apprenticePayments
+					}
+				};
+			}
+			catch (NotFoundException e)
+			{
+				return new OrchestratorResponse<CoursePaymentDetailsViewModel>
+				{
+					Status = HttpStatusCode.NotFound,
+					Exception = e
+				};
+			}
+			catch (InvalidRequestException e)
+			{
+				return new OrchestratorResponse<CoursePaymentDetailsViewModel>
+				{
+					Status = HttpStatusCode.BadRequest,
+					Exception = e
+				};
+			}
+			catch (UnauthorizedAccessException e)
+			{
+				return new OrchestratorResponse<CoursePaymentDetailsViewModel>
+				{
+					Status = HttpStatusCode.Unauthorized,
+					Exception = e
+				};
+			}
+		}
 
-        private static ICollection<TransactionLine> AggregateLevyTransactions(ICollection<TransactionLine> transactions)
-        {
-            if (transactions == null || transactions.Count == 0)
-                return new List<TransactionLine>();
+		private TransactionViewModel BuildTransactionViewModel(AggregationData aggregationData, int year, int month)
+		{
+			var viewModel = new TransactionViewModel
+			{
+				Data = new AggregationData
+				{
+					AccountId = aggregationData.AccountId,
+					HashedAccountId = aggregationData.HashedAccountId,
+				}
+			};
+			SetCurrentBalance(viewModel, aggregationData.TransactionLines, year, month);
+			SetTransactionLines(viewModel, aggregationData.TransactionLines);
+			return viewModel;
+		}
 
-            if (!transactions.HasAtLeast(2, t => t.TransactionType == TransactionItemType.Declaration))
-                return transactions;
+		private void SetCurrentBalance(TransactionViewModel viewModel, ICollection<TransactionLine> transactionLines, int year, int month)
+		{
+			var latestLineItem = transactionLines.FirstOrDefault();
 
-            var levyTransactions = transactions.Where(t => t.TransactionType == TransactionItemType.Declaration)
-                                               .ToList();
+			if (latestLineItem != null)
+			{
+				viewModel.CurrentBalance = latestLineItem.Balance;
+				viewModel.CurrentBalanceCalcultedOn = latestLineItem.TransactionDate;
+			}
+			else
+			{
+				viewModel.CurrentBalance = 0;
+				viewModel.CurrentBalanceCalcultedOn = new DateTime(year, month, 1).AddMonths(1).AddDays(-1);
+			}
+		}
 
-            var aggregatedTransactions = transactions.Except(levyTransactions).ToList();
+		private void SetTransactionLines(TransactionViewModel viewModel, ICollection<TransactionLine> transactionLines)
+		{
+			viewModel.Data.TransactionLines = AggregateLevyTransactions(transactionLines);
+		}
 
-            var levyTransaction = GetAggregatedLevyTransaction(levyTransactions);
+		private static ICollection<TransactionLine> AggregateLevyTransactions(ICollection<TransactionLine> transactions)
+		{
+			var result = new List<TransactionLine>();
 
-            aggregatedTransactions.Add(levyTransaction);
+			var aggregatedLevyTransactions = transactions
+				.Where(t => t.TransactionType == TransactionItemType.Declaration)
+				.GroupBy(t => t.DateCreated.Date)
+				.Select(grp =>
+				{
+					var firstLevyTransactionInDay = grp.First();
+					return new TransactionLine
+					{
+						AccountId = firstLevyTransactionInDay.AccountId,
+						DateCreated = firstLevyTransactionInDay.DateCreated,
+						Balance = firstLevyTransactionInDay.Balance,
+						Amount = grp.Sum(ltl => ltl.Amount),
+						TransactionType = TransactionItemType.Declaration,
+						Description = firstLevyTransactionInDay.Description,
+						PayrollDate = firstLevyTransactionInDay.PayrollDate,
+						PayrollMonth = firstLevyTransactionInDay.PayrollMonth,
+						PayrollYear = firstLevyTransactionInDay.PayrollYear
+					};
+				});
 
-
-            return aggregatedTransactions;
-        }
-
-        private static LevyDeclarationTransactionLine GetAggregatedLevyTransaction(List<TransactionLine> levyTransactions)
-        {
-            var maxDateCreated = DateTime.MinValue;
-            var totalAmount = 0m;
-            var maxTransactionDate = DateTime.MaxValue;
-
-            foreach (var transaction in levyTransactions)
-            {
-                if (transaction.DateCreated > maxDateCreated)
-                {
-                    maxDateCreated = transaction.DateCreated;
-                }
-
-                if (transaction.TransactionDate > maxTransactionDate)
-                {
-                    maxTransactionDate = transaction.TransactionDate;
-                }
-
-                totalAmount += transaction.Amount;
-            }
-
-            //We haven't populated all the values here as the view doesn't support them yet
-            var levyTransaction = new LevyDeclarationTransactionLine
-            {
-                Description = levyTransactions.First().Description,
-                DateCreated = maxDateCreated,
-                Amount = totalAmount,
-                TransactionType = TransactionItemType.Declaration,
-                TransactionDate = maxTransactionDate,
-                SubTransactions = levyTransactions
-            };
-
-
-            return levyTransaction;
-        }
-
-    }
+			return transactions
+				.Where(t => t.TransactionType != TransactionItemType.Declaration)
+				.Union(aggregatedLevyTransactions)
+				.ToList();
+		}
+	}
 }

--- a/src/SFA.DAS.EAS.Web/ViewModels/TransactionViewModel.cs
+++ b/src/SFA.DAS.EAS.Web/ViewModels/TransactionViewModel.cs
@@ -3,10 +3,10 @@ using SFA.DAS.EAS.Domain.Models.Transaction;
 
 namespace SFA.DAS.EAS.Web.ViewModels
 {
-    public class TransactionViewModel   
-    {
-        public decimal CurrentBalance { get; set; }
-        public DateTime CurrentBalanceCalcultedOn { get; set; }
-        public AggregationData Data { get; set; }
-    }
+	public class TransactionViewModel
+	{
+		public decimal CurrentBalance { get; set; }
+		public DateTime CurrentBalanceCalcultedOn { get; set; }
+		public AggregationData Data { get; set; }
+	}
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Extensions/EnumerableExtension.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Extensions/EnumerableExtension.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.EAS.Domain.Extensions
 
             foreach (var item in items)
             {
-                if (predicate.Invoke(item))
+                if (predicate(item))
                     foundItems++;
 
                 if (foundItems >= count)


### PR DESCRIPTION
Previously the levy declarations were aggregated to one per month, dated as the last levy declaration in that month. 
This is not the required behaviour.
A separate line for each day on which levy was paid should be shown. 

Also fixed a minor, unrelated bug which has the "balance at" date set to the system date even though the presented data related to a specific year and month. The date is now set to the month end of the relevant month.