### PR TITLE
Aml 2097 duplicate submission ids from hmrc

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/SFA.DAS.EAS.Employer_Financial.Database.sqlproj
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/SFA.DAS.EAS.Employer_Financial.Database.sqlproj
@@ -144,6 +144,7 @@
     <None Include="Scripts\Manual\AddNonTransferPayments.sql" />
     <None Include="Scripts\Manual\AddTransferLevy.sql" />
     <None Include="Scripts\Manual\CreateTransferPayments.sql" />
+    <None Include="Scripts\PreDeployment\RemoveDuplicateLevyDeclarations.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Database.publish.xml" />

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PostDeployment/SeedDevData.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PostDeployment/SeedDevData.sql
@@ -2,19 +2,22 @@
 	CREATE PROCEDURE #CreateLevy
 		@AccountId BIGINT,
 		@payeScheme NVARCHAR(50),
+		@SubmissionId BIGINT,
 		@levyAmount DECIMAL
 	AS
 	BEGIN
 		DECLARE @SubmissionDate DATETIME = GETDATE()
-
-		EXEC [employer_financial].[CreateDeclaration] @levyAmount, @payeScheme, @SubmissionDate, 123, 123, @AccountId, @levyAmount, ''17-18'', 1, @SubmissionDate, NULL, NULL, NULL, 0, 0, 0
+		IF (NOT EXISTS (SELECT 1 FROM [employer_financial].[LevyDeclaration] WHERE SubmissionId = @SubmissionId))
+		BEGIN 
+			EXEC [employer_financial].[CreateDeclaration] @levyAmount, @payeScheme, @SubmissionDate, @SubmissionId, 123, @AccountId, @levyAmount, ''17-18'', 1, @SubmissionDate, NULL, NULL, NULL, 0, 0, 0
+		END
 	END'
 
 EXEC sp_executesql @sqlStatement
 
-EXECUTE #CreateLevy 1, '222/AA00002', 500
-EXECUTE #CreateLevy 2, '123/SFAT029', 1000000
-EXECUTE #CreateLevy 3, '101/CUR00016', 0
+EXECUTE #CreateLevy 1, '222/AA00002', 126, 500
+EXECUTE #CreateLevy 2, '123/SFAT029', 127, 1000000
+EXECUTE #CreateLevy 3, '101/CUR00016', 128, 0
 EXECUTE [employer_financial].[ProcessDeclarationsTransactions] 1, '222/AA00002'
 EXECUTE [employer_financial].[ProcessDeclarationsTransactions] 2, '123/SFAT029'
 EXECUTE [employer_financial].[ProcessDeclarationsTransactions] 3, '101/CUR00016'

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PreDeployment/PreDeployment.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PreDeployment/PreDeployment.sql
@@ -9,3 +9,8 @@ Post-Deployment Script Template
                SELECT * FROM [$(TableName)]					
 --------------------------------------------------------------------------------------
 */
+-- ONLY DO THIS FOR DB UPGRADES - CHECK THE SCHEMA EXISTS!
+IF EXISTS (SELECT * FROM sys.schemas WHERE name = 'employer_financial')
+BEGIN
+	:r .\RemoveDuplicateLevyDeclarations.sql
+END

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PreDeployment/RemoveDuplicateLevyDeclarations.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Scripts/PreDeployment/RemoveDuplicateLevyDeclarations.sql
@@ -1,0 +1,46 @@
+﻿-- Store the original data 
+IF (NOT EXISTS (SELECT *  
+					FROM INFORMATION_SCHEMA.TABLES  
+					WHERE TABLE_SCHEMA = 'employer_financial'  
+					AND  TABLE_NAME = 'LevyDeclarationNonUnique')) 
+BEGIN 
+	SELECT 	[Id]
+			,[AccountId]
+			,[empRef]
+			,[LevyDueYTD]
+			,[LevyAllowanceForYear]
+			,[SubmissionDate]
+			,[SubmissionId]
+			,[PayrollYear]
+			,[PayrollMonth]
+			,[CreatedDate]
+			,[EndOfYearAdjustment]
+			,[EndOfYearAdjustmentAmount]
+			,[DateCeased]
+			,[InactiveFrom]
+			,[InactiveTo]
+			,[HmrcSubmissionId]
+			,[NoPaymentForPeriod]
+	INTO [employer_financial].[LevyDeclarationNonUnique] 
+			FROM [employer_financial].[LevyDeclaration]
+
+	-- Clean up the duplicates
+	DELETE ld FROM [employer_financial].[LevyDeclaration] ld
+	INNER JOIN (
+
+		SELECT ldd.EmpRef, ldd.[SubmissionId], Max(ldd.Id) AS maxId 
+		FROM [employer_financial].[LevyDeclaration] ldd
+		INNER JOIN (
+			SELECT [empRef], [SubmissionId] 
+			FROM employer_financial.LevyDeclaration 
+			GROUP BY [empRef], [SubmissionId] HAVING COUNT(*) > 1
+		) d 
+		ON d.empRef = ldd.[empRef] AND d.[SubmissionId] = ldd.[SubmissionId]
+		GROUP BY ldd.[empRef], ldd.[SubmissionId]
+
+	) dupes
+		ON dupes.[empRef] = ld.[empRef]
+		AND dupes.[SubmissionId] = ld.[SubmissionId]
+		AND dupes.maxId != ld.Id
+END 
+

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/Tables/LevyDeclaration.sql
@@ -9,7 +9,7 @@
     [SubmissionId] BIGINT NOT NULL DEFAULT 0,
 	[PayrollYear] NVARCHAR(10) NULL,
 	[PayrollMonth] TINYINT NULL,
-	[CreatedDate] DATETIME NOT NULL,
+	[CreatedDate] DATETIME NOT NULL DEFAULT GetDate(),
 	[EndOfYearAdjustment] BIT NOT NULL DEFAULT 0,
 	[EndOfYearAdjustmentAmount] DECIMAL(18,4) NULL,
 	[DateCeased] DATETIME NULL,
@@ -28,4 +28,7 @@ CREATE INDEX [IX_LevyDeclaration_EmpRef] ON [employer_financial].[LevyDeclaratio
 GO
 
 CREATE INDEX [IX_LevyDeclaration_Account_Payroll] ON [employer_financial].[LevyDeclaration] (AccountId,PayrollMonth,PayrollYear)
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IDX_UNIQUE_LevyDeclaration_PayeSchemeRef_SubmissionId] ON [employer_financial].[LevyDeclaration] (empref, submissionId)
 GO

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RefreshEmployerLevyData/RefreshEmployerLevyDataCommandHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RefreshEmployerLevyData/RefreshEmployerLevyDataCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.EAS.Application.Commands.PublishGenericEvent;
@@ -9,10 +10,12 @@ using SFA.DAS.EAS.Application.Exceptions;
 using SFA.DAS.EAS.Application.Factories;
 using SFA.DAS.EAS.Application.Validation;
 using SFA.DAS.EAS.Domain.Data.Repositories;
+using SFA.DAS.EAS.Domain.Extensions;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Domain.Models.Levy;
 using SFA.DAS.HashingService;
+using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData
 {
@@ -25,9 +28,10 @@ namespace SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData
         private readonly ILevyEventFactory _levyEventFactory;
         private readonly IGenericEventFactory _genericEventFactory;
         private readonly IHashingService _hashingService;
+        private readonly ILog _logger;
 
         public RefreshEmployerLevyDataCommandHandler(IValidator<RefreshEmployerLevyDataCommand> validator, IDasLevyRepository dasLevyRepository, IMediator mediator, IHmrcDateService hmrcDateService,
-            ILevyEventFactory levyEventFactory, IGenericEventFactory genericEventFactory, IHashingService hashingService)
+            ILevyEventFactory levyEventFactory, IGenericEventFactory genericEventFactory, IHashingService hashingService, ILog logger)
         {
             _validator = validator;
             _dasLevyRepository = dasLevyRepository;
@@ -36,6 +40,7 @@ namespace SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData
             _levyEventFactory = levyEventFactory;
             _genericEventFactory = genericEventFactory;
             _hashingService = hashingService;
+            _logger = logger;
         }
 
         protected override async Task HandleCore(RefreshEmployerLevyDataCommand message)
@@ -53,6 +58,8 @@ namespace SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData
             foreach (var employerLevyData in message.EmployerLevyData)
             {
                 var declarations = employerLevyData.Declarations.Declarations.OrderBy(c => c.SubmissionDate).ToArray();
+
+                declarations = FilterDuplicateHmrcDeclarations(employerLevyData.EmpRef, declarations);
 
                 declarations = await FilterActiveDeclarations(employerLevyData, declarations);
 
@@ -75,6 +82,23 @@ namespace SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData
             }
         }
 
+        /// <summary> 
+        /// If there are any Submissions from Hmrc that have the same submission Id, we should discard all 
+        /// but the first. 
+        /// </summary> 
+        private DasDeclaration[] FilterDuplicateHmrcDeclarations(string empRef,
+            DasDeclaration[] declarations)
+        { 
+            var duplicateIds = declarations.GroupBy(d => d.SubmissionId).Where(g => g.Count() > 1)
+                .Select(s => s.First().SubmissionId).ToList();
+
+            var submissionIds = string.Join(", ", duplicateIds);
+
+            _logger.Info($"PayeScheme '{empRef}' has duplicate submission id(s) from Hmrc = '{submissionIds}'");
+
+            return declarations.DistinctBy(x => x.SubmissionId).ToArray(); 
+        } 
+ 
         private async Task ProcessEndOfYearAdjustmentDeclarations(IEnumerable<DasDeclaration> declarations, EmployerLevyData employerLevyData)
         {
             var endOfYearAdjustmentDeclarations = declarations.Where(IsEndOfYearAdjustment).ToList();

--- a/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/ObjectMothers/RefreshEmployerLevyDataCommandObjectMother.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.TestCommon/ObjectMothers/RefreshEmployerLevyDataCommandObjectMother.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using SFA.DAS.EAS.Application.Commands.RefreshEmployerLevyData;
-using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Domain.Models.HmrcLevy;
 using SFA.DAS.EAS.Domain.Models.Levy;
 
@@ -28,24 +27,28 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             Id = "1",
                             LevyDueYtd = 10,
                             SubmissionDate = DateTime.UtcNow.AddMonths(-3),
+                            SubmissionId = 1
                         },
                         new DasDeclaration
                         {
                             Id = "2",
                             LevyDueYtd = 70,
-                            SubmissionDate = DateTime.UtcNow.AddMonths(-2)
+                            SubmissionDate = DateTime.UtcNow.AddMonths(-2),
+                            SubmissionId = 2
                         },
                         new DasDeclaration
                         {
                             Id = "3",
                             NoPaymentForPeriod = true,
-                            SubmissionDate = DateTime.UtcNow.AddMonths(-1)
+                            SubmissionDate = DateTime.UtcNow.AddMonths(-1),
+                            SubmissionId = 3
                         },
                         new DasDeclaration
                         {
                             Id = "4",
                             LevyDueYtd = 80,
-                            SubmissionDate = DateTime.UtcNow
+                            SubmissionDate = DateTime.UtcNow,
+                            SubmissionId = 4
                         }
                     }
                 }
@@ -57,6 +60,51 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
 
             return refreshEmployerLevyDataCommand;
         }
+
+        public static RefreshEmployerLevyDataCommand CreateDuplicateHmrcSubmissions(string empRef, long accountId = 1)
+        {
+
+            var refreshEmployerLevyDataCommand = new RefreshEmployerLevyDataCommand
+            {
+                AccountId = accountId,
+                EmployerLevyData = new List<EmployerLevyData> {
+                    new EmployerLevyData
+                    {
+                        EmpRef = empRef,
+                        Declarations = new DasDeclarations
+                        {
+                            Declarations = new List<DasDeclaration>
+                            {
+                                new DasDeclaration
+                                {
+                                    Id = "1",
+                                    LevyDueYtd = 10,
+                                    SubmissionDate = DateTime.UtcNow.AddMonths(-3),
+                                    SubmissionId = 1234
+                                },
+                                new DasDeclaration
+                                {
+                                    Id = "1",
+                                    LevyDueYtd = 10,
+                                    SubmissionDate = DateTime.UtcNow.AddMonths(-3),
+                                    SubmissionId = 1234
+                                },
+                                new DasDeclaration
+                                {
+                                    Id = "1",
+                                    LevyDueYtd = 10,
+                                    SubmissionDate = DateTime.UtcNow.AddMonths(-3),
+                                    SubmissionId = 1234
+                                },
+                            }
+                        }
+                    }
+                }
+            };
+
+            return refreshEmployerLevyDataCommand;
+        }
+
 
         public static RefreshEmployerLevyDataCommand CreateLevyDataWithFutureSubmissions(string empRef, DateTime submissionStartDate, long accountId = 1)
         {
@@ -77,7 +125,8 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(-3)),
                             PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(-3)),
                             LevyDueYtd = 10,
-                            SubmissionDate = submissionStartDate.AddMonths(-3)
+                            SubmissionDate = submissionStartDate.AddMonths(-3),
+                            SubmissionId = 1
                         },
                         new DasDeclaration
                         {
@@ -85,7 +134,9 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             LevyDueYtd = 70,
                             PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(-2)),
                             PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(-2)),
-                            SubmissionDate = submissionStartDate.AddMonths(-2)
+                            SubmissionDate = submissionStartDate.AddMonths(-2),
+                            SubmissionId = 2
+
                         },
                         new DasDeclaration
                         {
@@ -93,7 +144,9 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             LevyDueYtd = 75,
                             PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(-1)),
                             PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(-1)),
-                            SubmissionDate = submissionStartDate.AddMonths(-1)
+                            SubmissionDate = submissionStartDate.AddMonths(-1),
+                            SubmissionId = 3
+
                         },
                         new DasDeclaration
                         {
@@ -101,7 +154,9 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             LevyDueYtd = 80,
                             PayrollYear = GetPayrollYearFromDate(submissionStartDate),
                             PayrollMonth = GetPayrollMonthFromDate(submissionStartDate),
-                            SubmissionDate = submissionStartDate
+                            SubmissionDate = submissionStartDate,
+                            SubmissionId = 4
+
                         },
                         new DasDeclaration
                         {
@@ -109,7 +164,8 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                             LevyDueYtd = 90,
                             PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(1)),
                             PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(1)),
-                            SubmissionDate = submissionStartDate.AddMonths(1)
+                            SubmissionDate = submissionStartDate.AddMonths(1),
+                            SubmissionId = 5
                         },
 
                     }
@@ -128,30 +184,30 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
             var refreshEmployerLevyDataCommand = new RefreshEmployerLevyDataCommand
             {
                 AccountId = accountId,
-                EmployerLevyData = new List<EmployerLevyData> {
+                EmployerLevyData = new List<EmployerLevyData>
+                {
                     new EmployerLevyData
-                {
-                EmpRef = empRef,
-                Declarations = new DasDeclarations
-                {
-                    Declarations = new List<DasDeclaration>
                     {
-                        new DasDeclaration
+                        EmpRef = empRef,
+                        Declarations = new DasDeclarations
                         {
-                            Id = "1",
-                            LevyDueYtd = 10,
-                            PayrollYear = "16-17",
-                            PayrollMonth = 12,
-                            SubmissionDate = new DateTime(2017,05,01)
+                            Declarations = new List<DasDeclaration>
+                            {
+                                new DasDeclaration
+                                {
+                                    Id = "1",
+                                    LevyDueYtd = 10,
+                                    PayrollYear = "16-17",
+                                    PayrollMonth = 12,
+                                    SubmissionDate = new DateTime(2017, 05, 01),
+                                    SubmissionId = 1
+                                }
+                            }
                         }
-
                     }
                 }
-                }
-               }
 
             };
-
 
             return refreshEmployerLevyDataCommand;
         }
@@ -175,7 +231,8 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                                     PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(1)),
                                     PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(1)),
                                     LevyDueYtd = 10,
-                                    SubmissionDate = submissionStartDate.AddMonths(1)
+                                    SubmissionDate = submissionStartDate.AddMonths(1),
+                                    SubmissionId = 1
                                 },
                             }
                         }
@@ -192,7 +249,8 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                                     LevyDueYtd = 70,
                                     PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(2)),
                                     PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(2)),
-                                    SubmissionDate = submissionStartDate.AddMonths(2)
+                                    SubmissionDate = submissionStartDate.AddMonths(2),
+                                    SubmissionId = 2
                                 },
                                 new DasDeclaration
                                 {
@@ -200,7 +258,8 @@ namespace SFA.DAS.EAS.TestCommon.ObjectMothers
                                     LevyDueYtd = 75,
                                     PayrollYear = GetPayrollYearFromDate(submissionStartDate.AddMonths(1)),
                                     PayrollMonth = GetPayrollMonthFromDate(submissionStartDate.AddMonths(1)),
-                                    SubmissionDate = submissionStartDate.AddMonths(1)
+                                    SubmissionDate = submissionStartDate.AddMonths(1),
+                                    SubmissionId = 3
                                 }
                             }
                         }


### PR DESCRIPTION
In this PR we are going to:
Copy the LevyDeclaration data to a newly created table.
Delete any duplicated submisisonIds from the LevyDeclaration table.
Apply a Unique Index to the LevyDeclaration for EmpRef and SubmissionId.

Moving forward Importing Levy Declarations will strip out any duplicate submission Ids from the batch being processed so only one is added. ~If any duplicates were removed it will log this as info.