### PR TITLE
AML-2092 Transfers - Re-enter account ID option.

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/TransferConnectionInvitationsController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/TransferConnectionInvitationsController.cs
@@ -78,8 +78,8 @@ namespace SFA.DAS.EAS.Web.Controllers
                 case "Confirm":
                     var transferConnectionInvitationId = await _mediator.SendAsync(model.SendTransferConnectionInvitationCommand);
                     return RedirectToAction("Sent", new { transferConnectionInvitationId });
-                case "GoToTransfersPage":
-                    return RedirectToAction("Index", "Transfers");
+                case "ReEnterAccountId":
+                    return RedirectToAction("Start");
                 default:
                     throw new ArgumentOutOfRangeException(nameof(model.Choice));
             }

--- a/src/SFA.DAS.EAS.Web/ViewModels/TransferConnectionInvitations/SendTransferConnectionInvitationViewModel.cs
+++ b/src/SFA.DAS.EAS.Web/ViewModels/TransferConnectionInvitations/SendTransferConnectionInvitationViewModel.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.EAS.Web.ViewModels.TransferConnectionInvitations
     public class SendTransferConnectionInvitationViewModel
     {
         [Required(ErrorMessage = "Option required")]
-        [RegularExpression("Confirm|GoToTransfersPage", ErrorMessage = "Option required")]
+        [RegularExpression("Confirm|ReEnterAccountId", ErrorMessage = "Option required")]
         public string Choice { get; set; }
         
         public AccountDto ReceiverAccount { get; set; }

--- a/src/SFA.DAS.EAS.Web/Views/TransferConnectionInvitations/Send.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/TransferConnectionInvitations/Send.cshtml
@@ -42,8 +42,8 @@
                         Yes, I want to send a request to connect
                     </label>
                     <label class="block-label selection-button-radio">
-                        @Html.RadioButtonFor(m => m.Choice, "GoToTransfersPage")
-                        No, I want to go to the transfers dashboard
+                        @Html.RadioButtonFor(m => m.Choice, "ReEnterAccountId")
+                        No, I want to re-enter the account ID
                     </label>
                 </fieldset>
             </div>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/TransferConnectionInvitationsControllerTests/WhenISubmitTheSendTransferConnectionInvitationPage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/TransferConnectionInvitationsControllerTests/WhenISubmitTheSendTransferConnectionInvitationPage.cs
@@ -59,25 +59,24 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.TransferConnectionInvitationsCon
         [Test]
         public async Task ThenASendTransferConnectionCommandShouldNotBeSentIfIChoseOption2()
         {
-            _viewModel.Choice = "GoToTransfersPage";
+            _viewModel.Choice = "ReEnterAccountId";
 
             await _controller.Send(_viewModel);
 
             _mediator.Verify(m => m.SendAsync(_viewModel.SendTransferConnectionInvitationCommand), Times.Never);
         }
-
+        
         [Test]
-        public async Task ThenIShouldBeRedirectedToTheTransfersPageIfIChoseOption2()
+        public async Task ThenIShouldBeRedirectedToStartPageIfIChoseOption2()
         {
-            _viewModel.Choice = "GoToTransfersPage";
+            _viewModel.Choice = "ReEnterAccountId";
 
             var result = await _controller.Send(_viewModel) as RedirectToRouteResult;
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.RouteValues.TryGetValue("action", out var actionName), Is.True);
-            Assert.That(actionName, Is.EqualTo("Index"));
-            Assert.That(result.RouteValues.TryGetValue("controller", out var controllerName), Is.True);
-            Assert.That(controllerName, Is.EqualTo("Transfers"));
+            Assert.That(actionName, Is.EqualTo("Start"));
+            Assert.That(result.RouteValues.ContainsKey("controller"), Is.False);
         }
     }
 }


### PR DESCRIPTION
When doing an transfer invite, after entering an account ID you can try another Account ID if you get a successful Account returned. You no longer have the "Go to transfer dashboard" option!
