### PR TITLE
Aml 2299 include inner exceptions

### DIFF
--- a/src/SFA.DAS.EAS.Account.Worker/WorkerRole.cs
+++ b/src/SFA.DAS.EAS.Account.Worker/WorkerRole.cs
@@ -1,10 +1,9 @@
-using System;
-using Microsoft.Azure.WebJobs;
 using Microsoft.WindowsAzure.ServiceRuntime;
+using NLog;
 using SFA.DAS.EAS.Account.Worker.DependencyResolution;
-using SFA.DAS.EAS.Account.Worker.Infrastructure;
-using SFA.DAS.EAS.Account.Worker.Infrastructure.Interfaces;
+using SFA.DAS.EAS.Application.DependencyResolution;
 using SFA.DAS.EAS.Infrastructure.Extensions;
+using SFA.DAS.Messaging.Interfaces;
 using StructureMap;
 using System;
 using System.Linq;
@@ -16,26 +15,72 @@ namespace SFA.DAS.EAS.Account.Worker
 {
     public class WorkerRole : RoleEntryPoint
     {
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-        private IContainer _container;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly ManualResetEvent _runCompleteEvent = new ManualResetEvent(false);
 
         public override void Run()
         {
-            _container = IoC.Initialize();
-            ServiceLocator.Initialise(_container);
+            Logger.Info("SFA.DAS.EAS.Account.Worker is running");
+
+            try
+            {
+                var container = new Container(c =>
+                {
+                    c.AddRegistry<CachesRegistry>();
+                    c.AddRegistry<ConfigurationRegistry>();
+                    c.AddRegistry<HashingRegistry>();
+                    c.AddRegistry<LoggerRegistry>();
+                    c.AddRegistry<MapperRegistry>();
+                    c.AddRegistry<MediatorRegistry>();
+                    c.AddRegistry<MessagePublisherRegistry>();
+                    c.AddRegistry<MessageSubscriberRegistry>();
+                    c.AddRegistry<RepositoriesRegistry>();
+                    c.AddRegistry<DefaultRegistry>();
+                });
+
+                var messageProcessors = container.GetAllInstances<IMessageProcessor>().ToList();
+                var tasks = messageProcessors.Select(p => p.RunAsync(_cancellationTokenSource)).ToArray();
+
+                Task.WaitAll(tasks);
+            }
+            catch (Exception ex)
+            {
                 Logger.Fatal(ex, ex.GetMessage());
+                throw;
+            }
+            finally
+            {
+                _runCompleteEvent.Set();
+            }
+        }
 
-            var webjobhelper = _container.GetInstance<IAzureWebJobHelper>();
-            webjobhelper.EnsureAllQueuesForTriggeredJobs();
+        public override bool OnStart()
+        {
+            // Set the maximum number of concurrent connections
+            ServicePointManager.DefaultConnectionLimit = 12;
 
-            var host = _container.GetInstance<JobHost>();
-            host.RunAndBlock();
+            // For information on handling configuration changes
+            // see the MSDN topic at https://go.microsoft.com/fwlink/?LinkId=166357.
+
+            var result = base.OnStart();
+
+            Logger.Info("SFA.DAS.EAS.Account.Worker has been started");
+
+            return result;
         }
 
         public override void OnStop()
         {
-            _container?.Dispose();
-            
+            Logger.Info("SFA.DAS.EAS.Account.Worker is stopping");
+
+            _cancellationTokenSource.Cancel();
+            _runCompleteEvent.WaitOne();
+
+            base.OnStop();
+
+            Logger.Info("SFA.DAS.EAS.Account.Worker has stopped");
         }
     }
 }

--- a/src/SFA.DAS.EAS.Account.Worker/WorkerRole.cs
+++ b/src/SFA.DAS.EAS.Account.Worker/WorkerRole.cs
@@ -1,9 +1,16 @@
+using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using SFA.DAS.EAS.Account.Worker.DependencyResolution;
 using SFA.DAS.EAS.Account.Worker.Infrastructure;
 using SFA.DAS.EAS.Account.Worker.Infrastructure.Interfaces;
+using SFA.DAS.EAS.Infrastructure.Extensions;
 using StructureMap;
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.EAS.Account.Worker
 {
@@ -16,6 +23,7 @@ namespace SFA.DAS.EAS.Account.Worker
         {
             _container = IoC.Initialize();
             ServiceLocator.Initialise(_container);
+                Logger.Fatal(ex, ex.GetMessage());
 
             var webjobhelper = _container.GetInstance<IAzureWebJobHelper>();
             webjobhelper.EnsureAllQueuesForTriggeredJobs();
@@ -27,6 +35,7 @@ namespace SFA.DAS.EAS.Account.Worker
         public override void OnStop()
         {
             _container?.Dispose();
+            
         }
     }
 }

--- a/src/SFA.DAS.EAS.Api/ExceptionLoggers/ErrorLogger.cs
+++ b/src/SFA.DAS.EAS.Api/ExceptionLoggers/ErrorLogger.cs
@@ -3,6 +3,7 @@ using System.Web.Http.ExceptionHandling;
 using Microsoft.ApplicationInsights;
 using NLog;
 using SFA.DAS.EAS.Application.Extensions;
+using SFA.DAS.EAS.Infrastructure.Extensions;
 
 namespace SFA.DAS.EAS.Account.Api.ExceptionLoggers
 {

--- a/src/SFA.DAS.EAS.Api/ExceptionLoggers/ErrorLogger.cs
+++ b/src/SFA.DAS.EAS.Api/ExceptionLoggers/ErrorLogger.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Web.Http.ExceptionHandling;
-using Microsoft.ApplicationInsights;
+﻿using Microsoft.ApplicationInsights;
 using NLog;
-using SFA.DAS.EAS.Application.Extensions;
 using SFA.DAS.EAS.Infrastructure.Extensions;
+using System.Collections.Generic;
+using System.Web.Http.ExceptionHandling;
 
 namespace SFA.DAS.EAS.Account.Api.ExceptionLoggers
 {

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/Extensions/ExceptionExtensionTests.cs
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/Extensions/ExceptionExtensionTests.cs
@@ -1,11 +1,11 @@
-﻿using NUnit.Framework;
-using SFA.DAS.EAS.Infrastructure.Extensions;
-using System;
+﻿using System;
 using System.Globalization;
 using System.Net;
 using System.Web;
+using NUnit.Framework;
+using SFA.DAS.EAS.Infrastructure.Extensions;
 
-namespace SFA.DAS.EAS.Support.Infrastructure.Tests.Extensions
+namespace SFA.DAS.EAS.Infrastructure.UnitTests.Extensions
 {
     [TestFixture]
     public class ExceptionExtensionTests

--- a/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.EAS.Infrastructure.UnitTests/SFA.DAS.EAS.Infrastructure.UnitTests.csproj
@@ -200,6 +200,7 @@
     <Compile Include="ExecutionPoliciesTests\Hmrc\WhenIMakeABadRequest.cs" />
     <Compile Include="ExecutionPoliciesTests\CompanyHouse\WhenILookUpACompanyThatDoesNotExist.cs" />
     <Compile Include="Extensions\EnumerableExtensionsTests.cs" />
+    <Compile Include="Extensions\ExceptionExtensionTests.cs" />
     <Compile Include="Extensions\PaymentDetailsExtensionsTests.cs" />
     <Compile Include="Factories\WhenICreateARestClient.cs" />
     <Compile Include="Features\AgreementServiceTests.cs" />

--- a/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/Program.cs
+++ b/src/SFA.DAS.EAS.LevyAccountUpdater.WebJob/Program.cs
@@ -1,20 +1,34 @@
-﻿using SFA.DAS.EAS.Infrastructure.Logging;
+﻿using NLog;
+using SFA.DAS.EAS.Infrastructure.Extensions;
+using SFA.DAS.EAS.Infrastructure.Logging;
 using SFA.DAS.EAS.LevyAccountUpdater.WebJob.DependencyResolution;
 using SFA.DAS.EAS.LevyAccountUpdater.WebJob.Updater;
+using System;
 
 namespace SFA.DAS.EAS.LevyAccountUpdater.WebJob
 {
     class Program
     {
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         static void Main(string[] args)
         {
             LoggingConfig.ConfigureLogging();
 
             var container = IoC.Initialize();
 
-            var updater = container.GetInstance<IAccountUpdater>();
+            try
+            {
+                var updater = container.GetInstance<IAccountUpdater>();
 
-            updater.RunUpdate().Wait();
+                updater.RunUpdate().Wait();
+            }
+            catch (Exception ex)
+            {
+                Logger.Fatal(ex, ex.GetMessage());
+                throw;
+            }
+
         }
     }
 

--- a/src/SFA.DAS.EAS.PaymentUpdater.WebJob/Program.cs
+++ b/src/SFA.DAS.EAS.PaymentUpdater.WebJob/Program.cs
@@ -1,12 +1,17 @@
-﻿using SFA.DAS.EAS.Infrastructure.Logging;
+﻿using NLog;
+using SFA.DAS.EAS.Infrastructure.Extensions;
+using SFA.DAS.EAS.Infrastructure.Logging;
 using SFA.DAS.EAS.PaymentUpdater.WebJob.DependencyResolution;
 using SFA.DAS.EAS.PaymentUpdater.WebJob.Updater;
+using System;
 
 namespace SFA.DAS.EAS.PaymentUpdater.WebJob
 {
     // To learn more about Microsoft Azure WebJobs SDK, please see http://go.microsoft.com/fwlink/?LinkID=320976
     public class Program
     {
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         // Please set the following connection strings in app.config for this WebJob to run:
         // AzureWebJobsDashboard and AzureWebJobsStorage
         static void Main()
@@ -15,9 +20,18 @@ namespace SFA.DAS.EAS.PaymentUpdater.WebJob
 
             var container = IoC.Initialize();
 
-            var paymentUpdater = container.GetInstance<IPaymentProcessor>();
+            try
+            {
+                var paymentUpdater = container.GetInstance<IPaymentProcessor>();
 
-            paymentUpdater.RunUpdate().Wait();
+                paymentUpdater.RunUpdate().Wait();
+            }
+            catch (Exception ex)
+            {
+                Logger.Fatal(ex, ex.GetMessage());
+                throw;
+            }
+
         }
     }
 }

--- a/src/SFA.DAS.EAS.Support.Infrastructure.Tests/Extensions/ExceptionExtensionTests.cs
+++ b/src/SFA.DAS.EAS.Support.Infrastructure.Tests/Extensions/ExceptionExtensionTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using SFA.DAS.EAS.Application.Extensions;
+using SFA.DAS.EAS.Infrastructure.Extensions;
+
+namespace SFA.DAS.EAS.Support.Infrastructure.Tests.Extensions
+{
+    [TestFixture]
+    public class ExceptionExtensionTests
+    {
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithException_GetsExceptionHandler()
+        {
+            TestExpectedExceptionHandler(new Exception("outermessage"), typeof(Exception));
+        }
+
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithAggregateException_GetsAggregateExceptionHandler()
+        {
+            TestExpectedExceptionHandler(new AggregateException("outermessage"), typeof(AggregateException));
+        }
+
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithHttpException_GetsHttpExceptionHandler()
+        {
+            TestExpectedExceptionHandler(new HttpException("outermessage"), typeof(HttpException));
+        }
+
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithNonExplicitlySupportedException_GetsBestFitHandlerWhenDirectDescendent()
+        {
+            TestExpectedExceptionHandler(new ChildOfException(), typeof(Exception));
+        }
+
+
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithNonExplicitlySupportedException_GetsBestFitHandlerWhenAFewTypesDown()
+        {
+            TestExpectedExceptionHandler(new GrandChildOfException(), typeof(Exception));
+        }
+
+        [Test]
+        public void GetAppropriateExceptionFormatter_WhenCalledWithNonExplicitlySupportedException_GetsBestFitHandlerWhenAFewMoreTypesDown()
+        {
+            TestExpectedExceptionHandler(new GreatGrandChildOfException(), typeof(Exception));
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithException_ContainsExceptionType()
+        {
+            TestDetailedMessage(new Exception("outer"), nameof(Exception));
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithException_ContainsExceptionMessage()
+        {
+            TestDetailedMessage(new Exception("outer"), "outer");
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithInnerException_ContainsOuterExceptionType()
+        {
+            TestDetailedMessage(new Exception("outer", new ApplicationException("inner")), nameof(Exception));
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithInnerException_ContainsOuterExceptionMessage()
+        {
+            TestDetailedMessage(new Exception("outer", new ApplicationException("inner")), "outer");
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithInnerException_ContainsInnerExceptionType()
+        {
+            TestDetailedMessage(new Exception("outer", new ApplicationException("inner")), nameof(ApplicationException));
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithInnerException_ContainsInnerExceptionMessage()
+        {
+            TestDetailedMessage(new Exception("outer", new ApplicationException("inner")), "inner");
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithAggregateException_ContainsAllExceptionessages()
+        {
+            TestDetailedMessage(new AggregateException(
+                new Exception("aggregate1"),
+                new ApplicationException("aggregate2"),
+                new HttpException("aggregate3")),
+                "aggregate1", "aggregate2", "aggregate3");
+        }
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithAggregateExceptionWithInnerExceptions_ContainsAllOuterExceptionessages()
+        {
+            TestDetailedMessage(new AggregateException(
+                    new Exception("aggregate1", new Exception("inner1")),
+                    new ApplicationException("aggregate2", new Exception("inner2")),
+                    new HttpException("aggregate3", new Exception("inner3"))),
+                "aggregate1", "aggregate2", "aggregate3");
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithAggregateExceptionWithInnerExceptions_ContainsAllInnerExceptionessages()
+        {
+            TestDetailedMessage(new AggregateException(
+                    new Exception("aggregate1", new Exception("inner1")),
+                    new ApplicationException("aggregate2", new Exception("inner2")),
+                    new HttpException("aggregate3", new Exception("inner3"))),
+                "inner1", "inner2", "inner3");
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithHttpExceptions_ContainsHttpErrorCode()
+        {
+            TestDetailedMessage(new HttpException((int)HttpStatusCode.Conflict, ""),
+                ((int) HttpStatusCode.Conflict).ToString(CultureInfo.InvariantCulture));
+        }
+
+        [Test]
+        public void GetDetailedMessage_WhenCalledWithHttpExceptions_ContainsHttpMessage()
+        {
+            const string webFailureMessage = "Sorry Dave, I can't let you do that.";
+            TestDetailedMessage(new HttpException((int)HttpStatusCode.Conflict, webFailureMessage),
+                webFailureMessage);
+        }
+
+        private void TestExpectedExceptionHandler(Exception exception, Type expectedExceptionType)
+        {
+            var actualHandler = ExceptionExtensions.GetAppropriateExceptionFormatter(exception);
+
+            Assert.AreEqual(actualHandler.SupportedException, expectedExceptionType);
+        }
+
+        private void TestDetailedMessage(Exception exception, params string[] expectedMessageContents)
+        {
+            var detailedMessage = ExceptionExtensions.GetMessage(exception);
+
+            foreach (var part in expectedMessageContents)
+            {
+                Assert.IsTrue(detailedMessage.Contains(part), $"detailed message {detailedMessage} does not contain expected part {part}");
+            }
+        }
+    }
+
+    class ChildOfException : Exception
+    {
+
+    }
+
+    class GrandChildOfException : ChildOfException
+    {
+
+    }
+
+    class GreatGrandChildOfException : GrandChildOfException
+    {
+
+    }
+}

--- a/src/SFA.DAS.EAS.Support.Infrastructure.Tests/Extensions/ExceptionExtensionTests.cs
+++ b/src/SFA.DAS.EAS.Support.Infrastructure.Tests/Extensions/ExceptionExtensionTests.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
-using NUnit.Framework;
-using NUnit.Framework.Internal;
-using SFA.DAS.EAS.Application.Extensions;
+﻿using NUnit.Framework;
 using SFA.DAS.EAS.Infrastructure.Extensions;
+using System;
+using System.Globalization;
+using System.Net;
+using System.Web;
 
 namespace SFA.DAS.EAS.Support.Infrastructure.Tests.Extensions
 {
@@ -122,7 +116,7 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Tests.Extensions
         public void GetDetailedMessage_WhenCalledWithHttpExceptions_ContainsHttpErrorCode()
         {
             TestDetailedMessage(new HttpException((int)HttpStatusCode.Conflict, ""),
-                ((int) HttpStatusCode.Conflict).ToString(CultureInfo.InvariantCulture));
+                ((int)HttpStatusCode.Conflict).ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -142,7 +136,7 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Tests.Extensions
 
         private void TestDetailedMessage(Exception exception, params string[] expectedMessageContents)
         {
-            var detailedMessage = ExceptionExtensions.GetMessage(exception);
+            var detailedMessage = exception.GetMessage();
 
             foreach (var part in expectedMessageContents)
             {

--- a/src/SFA.DAS.EAS.Support.Infrastructure.Tests/SFA.DAS.EAS.Support.Infrastructure.Tests.csproj
+++ b/src/SFA.DAS.EAS.Support.Infrastructure.Tests/SFA.DAS.EAS.Support.Infrastructure.Tests.csproj
@@ -99,7 +99,6 @@
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionFinance.cs" />
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionOrganisations.cs" />
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionTeamMembers.cs" />
-    <Compile Include="Extensions\ExceptionExtensionTests.cs" />
     <Compile Include="LevySubmissionsRepository\WhenTestingLevySubmissionsRepository.cs" />
     <Compile Include="AccountRepository\WhenTestingAccountRepository.cs" />
     <Compile Include="ChallengeRepository\WhenTestingChallengeRepository.cs" />

--- a/src/SFA.DAS.EAS.Support.Infrastructure.Tests/SFA.DAS.EAS.Support.Infrastructure.Tests.csproj
+++ b/src/SFA.DAS.EAS.Support.Infrastructure.Tests/SFA.DAS.EAS.Support.Infrastructure.Tests.csproj
@@ -78,6 +78,7 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
@@ -98,6 +99,7 @@
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionFinance.cs" />
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionOrganisations.cs" />
     <Compile Include="AccountRepository\WhenCallingGetWithAccountFieldsSelectionTeamMembers.cs" />
+    <Compile Include="Extensions\ExceptionExtensionTests.cs" />
     <Compile Include="LevySubmissionsRepository\WhenTestingLevySubmissionsRepository.cs" />
     <Compile Include="AccountRepository\WhenTestingAccountRepository.cs" />
     <Compile Include="ChallengeRepository\WhenTestingChallengeRepository.cs" />
@@ -127,6 +129,10 @@
     <ProjectReference Include="..\SFA.DAS.EAS.Support.Infrastructure\SFA.DAS.EAS.Support.Infrastructure.csproj">
       <Project>{9A31DB97-209C-48EF-AE2A-B4A4F761F670}</Project>
       <Name>SFA.DAS.EAS.Support.Infrastructure</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SFA.DAS.EmployerApprenticeshipsService.Infrastructure\SFA.DAS.EAS.Infrastructure.csproj">
+      <Project>{01AC2BC2-AC01-400F-AB8F-548DD5C0EE74}</Project>
+      <Name>SFA.DAS.EAS.Infrastructure</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.EAS.Web/Global.asax.cs
+++ b/src/SFA.DAS.EAS.Web/Global.asax.cs
@@ -19,6 +19,7 @@ using SFA.DAS.Audit.Client.Web;
 using SFA.DAS.Audit.Types;
 using SFA.DAS.EAS.Application.Extensions;
 using SFA.DAS.EAS.Infrastructure.DependencyResolution;
+using SFA.DAS.EAS.Infrastructure.Extensions;
 using SFA.DAS.EAS.Infrastructure.Logging;
 using SFA.DAS.EAS.Web.ViewModels;
 using SFA.DAS.EmployerUsers.WebClientComponents;

--- a/src/SFA.DAS.EAS.Web/Global.asax.cs
+++ b/src/SFA.DAS.EAS.Web/Global.asax.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿using FluentValidation.Mvc;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure;
+using NLog;
+using NLog.Targets;
+using SFA.DAS.Audit.Client;
+using SFA.DAS.Audit.Client.Web;
+using SFA.DAS.Audit.Types;
+using SFA.DAS.EAS.Infrastructure.DependencyResolution;
+using SFA.DAS.EAS.Infrastructure.Extensions;
+using SFA.DAS.EAS.Infrastructure.Logging;
+using SFA.DAS.EAS.Web.ViewModels;
+using SFA.DAS.EmployerUsers.WebClientComponents;
+using SFA.DAS.Web.Policy;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
@@ -8,22 +23,6 @@ using System.Web.Helpers;
 using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
-using FluentValidation.Mvc;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Azure;
-using NLog;
-using NLog.Targets;
-using SFA.DAS.Audit.Client;
-using SFA.DAS.Audit.Client.Web;
-using SFA.DAS.Audit.Types;
-using SFA.DAS.EAS.Application.Extensions;
-using SFA.DAS.EAS.Infrastructure.DependencyResolution;
-using SFA.DAS.EAS.Infrastructure.Extensions;
-using SFA.DAS.EAS.Infrastructure.Logging;
-using SFA.DAS.EAS.Web.ViewModels;
-using SFA.DAS.EmployerUsers.WebClientComponents;
-using SFA.DAS.Web.Policy;
 using Environment = SFA.DAS.EAS.Infrastructure.DependencyResolution.Environment;
 
 namespace SFA.DAS.EAS.Web
@@ -81,7 +80,7 @@ namespace SFA.DAS.EAS.Web
             {
                 return;
             }
-            
+
             Dictionary<string, object> properties = null;
 
             try

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Extensions/ExceptionExtensions.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Extensions/ExceptionExtensions.cs
@@ -6,6 +6,8 @@ namespace SFA.DAS.EAS.Application.Extensions
 {
     public static class ExceptionExtensions
     {
+        #region original method
+
         public static string GetMessage(this Exception ex)
         {
             var newlines = Environment.NewLine.ToArray();
@@ -21,5 +23,124 @@ namespace SFA.DAS.EAS.Application.Extensions
 
             return messageBuilder.ToString();
         }
+
+        #endregion Begin region         
+
+        #region new code
+
+        private class ExceptionTypeFormatter
+        {
+            public ExceptionTypeFormatter(Type supportedException, Action<Exception, StringBuilder> builder)
+            {
+                SupportedException = supportedException;
+                Build = builder;
+            }
+
+            public Type SupportedException { get;  }
+            public Action<Exception, StringBuilder> Build { get; }
+        }
+
+        private static readonly ExceptionTypeFormatter LastChanceFormatter = new ExceptionTypeFormatter(typeof(Exception), BuildLastChanceMessage);
+
+        private static readonly ExceptionTypeFormatter[] ExceptionFormatters = new[]
+        {
+            // This will catch all exceptions
+            new ExceptionTypeFormatter(typeof(Exception), BuildExceptionMessage),
+            new ExceptionTypeFormatter(typeof(AggregateException), BuildAggregateExceptionMessage)
+        };
+
+
+        public static string GetDetailedExceptionMessage(Exception exception)
+        {
+            const int reasonableInitialMessageSize = 200;
+            var messageBuilder = new StringBuilder(reasonableInitialMessageSize);
+
+            BuildDetailedExceptionMessage(exception, messageBuilder);
+
+            return messageBuilder.ToString();
+        }
+
+        private static void BuildDetailedExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            var handler = GetAppropriateExceptionFormatter(exception);
+            handler.Build(exception, messageBuilder);
+
+            BuildAggregateExceptionMessage(exception.InnerException, messageBuilder);
+        }
+
+        private static ExceptionTypeFormatter GetAppropriateExceptionFormatter(Exception exception)
+        {
+            ExceptionTypeFormatter result = null;
+
+            if (exception == null)
+            {
+                result = LastChanceFormatter;
+            }
+            else
+            {
+                var exceptionType = exception.GetType();
+
+                while (result == null)
+                {
+                    // convert to dictionary
+                    result = ExceptionFormatters.First(ef => ef.SupportedException == exceptionType);
+                    if (result == null)
+                    {
+                        if (exceptionType.BaseType == null)
+                        {
+                            return LastChanceFormatter;
+                        }
+
+                        exceptionType = exceptionType.BaseType;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static void BuildLastChanceMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            if (exception == null)
+            {
+                messageBuilder.Append("Exception is null");
+            }
+            else
+            { 
+                messageBuilder.Append("Exception:");
+                messageBuilder.Append(exception.GetType().Name);
+                messageBuilder.Append(" Message:");
+                messageBuilder.Append(exception.Message);
+            }
+        }
+
+        private static void BuildExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            messageBuilder.Append("Exception:");
+            messageBuilder.Append(exception.GetType().Name);
+            messageBuilder.Append(" Message:");
+            messageBuilder.Append(exception.Message);
+        }
+
+        private static void BuildAggregateExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            var exceptions = ((AggregateException) exception).Flatten();
+
+            messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
+            for (int i = 0; i < exceptions.InnerExceptions.Count; i++)
+            {
+                messageBuilder.Append("exception ");
+                messageBuilder.Append(i);
+                messageBuilder.Append(':');
+                BuildDetailedExceptionMessage(exceptions.InnerExceptions[i], messageBuilder);
+            }
+        }
+
+        #endregion Begin region         
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/SendTransferConnectionInvitation/SendTransferConnectionInvitationQueryHandler.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Queries/SendTransferConnectionInvitation/SendTransferConnectionInvitationQueryHandler.cs
@@ -5,7 +5,6 @@ using AutoMapper.QueryableExtensions;
 using MediatR;
 using SFA.DAS.EAS.Application.Dtos;
 using SFA.DAS.EAS.Application.Exceptions;
-using SFA.DAS.EAS.Application.Extensions;
 using SFA.DAS.EAS.Application.Hashing;
 using SFA.DAS.EAS.Domain.Models.TransferConnections;
 using SFA.DAS.EAS.Infrastructure.Data;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/SFA.DAS.EAS.Application.csproj
@@ -454,7 +454,6 @@
     <Compile Include="Events\ProcessDeclaration\ProcessDeclarationsEventHandler.cs" />
     <Compile Include="Events\ProcessPayment\ProcessPaymentEvent.cs" />
     <Compile Include="Events\ProcessPayment\ProcessPaymentEventHandler.cs" />
-    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Factories\LevyEventFactory.cs" />
     <Compile Include="Factories\AccountEventFactory.cs" />
     <Compile Include="Factories\EmployerAgreementEventFactory.cs" />
@@ -783,7 +782,9 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
@@ -1,0 +1,56 @@
+﻿using SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using ExceptionMessageFormatter = SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters.ExceptionMessageFormatter;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions
+{
+    internal static class ExceptionMessageFormatterFactory
+    {
+        private static readonly ConcurrentDictionary<Type, IExceptionMessageFormatter> ExceptionMessageFormatterCache =
+            new ConcurrentDictionary<Type, IExceptionMessageFormatter>();
+
+        private static IExceptionMessageFormatter GeneralExceptionFormatter => new ExceptionMessageFormatter();
+
+        private static readonly IExceptionMessageFormatter[] ExceptionFormatters =
+        {
+            new AggregateExceptionMessageFormatter(GetFormatter),
+            new HttpExceptionMessageFormatter(),
+        };
+
+        public static IExceptionMessageFormatter GetFormatter(Exception exception)
+        {
+            return ExceptionMessageFormatterCache.GetOrAdd(exception.GetType(), GetExceptionFormatter(exception));
+        }
+
+        private static IExceptionMessageFormatter GetExceptionFormatter(Exception exception)
+        {
+            IExceptionMessageFormatter formatter = null;
+
+            if (exception == null)
+            {
+                return GeneralExceptionFormatter;
+            }
+
+            var exceptionType = exception.GetType();
+
+            while (formatter == null)
+            {
+                // convert to dictionary
+                formatter = ExceptionFormatters.FirstOrDefault(ef => ef.SupportedException == exceptionType);
+
+                if (formatter != null) continue;
+
+                if (exceptionType.BaseType == null)
+                {
+                    return GeneralExceptionFormatter;
+                }
+
+                exceptionType = exceptionType.BaseType;
+            }
+
+            return formatter;
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
@@ -11,13 +11,13 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions
         private static readonly ConcurrentDictionary<Type, IExceptionMessageFormatter> ExceptionMessageFormatterCache =
             new ConcurrentDictionary<Type, IExceptionMessageFormatter>();
 
-        private static IExceptionMessageFormatter GeneralExceptionFormatter => new ExceptionMessageFormatter(GetFormatter);
+        private static IExceptionMessageFormatter GeneralExceptionFormatter => new ExceptionMessageFormatter();
 
         private static readonly IExceptionMessageFormatter[] ExceptionFormatters =
         {
-            new AggregateExceptionMessageFormatter(GetFormatter),
-            new HttpExceptionMessageFormatter(GetFormatter),
-            new ExceptionMessageFormatter(GetFormatter)
+            new AggregateExceptionMessageFormatter(),
+            new HttpExceptionMessageFormatter(),
+            new ExceptionMessageFormatter()
         };
 
         public static IExceptionMessageFormatter GetFormatter(Exception exception)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/ExceptionMessageFormatterFactory.cs
@@ -11,12 +11,13 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions
         private static readonly ConcurrentDictionary<Type, IExceptionMessageFormatter> ExceptionMessageFormatterCache =
             new ConcurrentDictionary<Type, IExceptionMessageFormatter>();
 
-        private static IExceptionMessageFormatter GeneralExceptionFormatter => new ExceptionMessageFormatter();
+        private static IExceptionMessageFormatter GeneralExceptionFormatter => new ExceptionMessageFormatter(GetFormatter);
 
         private static readonly IExceptionMessageFormatter[] ExceptionFormatters =
         {
             new AggregateExceptionMessageFormatter(GetFormatter),
-            new HttpExceptionMessageFormatter(),
+            new HttpExceptionMessageFormatter(GetFormatter),
+            new ExceptionMessageFormatter(GetFormatter)
         };
 
         public static IExceptionMessageFormatter GetFormatter(Exception exception)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/Formatters/IExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/Formatters/IExceptionMessageFormatter.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions
+{
+    internal interface IExceptionMessageFormatter
+    {
+        string GetFormattedMessage(Exception exception);
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
@@ -5,16 +5,13 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal class AggregateExceptionMessageFormatter : BaseExceptionMessageFormatter
     {
-        private readonly Func<Exception, IExceptionMessageFormatter> _getExecptionFormatterCallback;
 
         public override Type SupportedException => typeof(AggregateException);
 
-        public AggregateExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback)
-        {
-            _getExecptionFormatterCallback = getExecptionFormatterCallback;
-        }
+        public AggregateExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback) : base(getExecptionFormatterCallback)
+        { }
 
-        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             var exceptions = ((AggregateException)exception).Flatten();
 
@@ -22,12 +19,16 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 
             for (var i = 0; i < exceptions.InnerExceptions.Count; i++)
             {
-                messageBuilder.Append("Exception:");
-                messageBuilder.Append(i);
+                messageBuilder.AppendLine($"Exception: {i} ");
 
                 var formatter = _getExecptionFormatterCallback(exceptions.InnerExceptions[i]);
                 formatter.AppendFormattedMessage(exceptions.InnerExceptions[i], messageBuilder);
             }
+        }
+
+        protected override void CreateInnerExceptionMessages(Exception exception, StringBuilder messageBuilder)
+        {
+            //We already handle inner exceptions above so we do not need to process them here
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Text;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
+{
+    internal class AggregateExceptionMessageFormatter : BaseExceptionMessageFormatter
+    {
+        private readonly Func<Exception, IExceptionMessageFormatter> _getExecptionFormatterCallback;
+
+        public override Type SupportedException => typeof(AggregateException);
+
+        public AggregateExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback)
+        {
+            _getExecptionFormatterCallback = getExecptionFormatterCallback;
+        }
+
+        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            var exceptions = ((AggregateException)exception).Flatten();
+
+            messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
+
+            for (var i = 0; i < exceptions.InnerExceptions.Count; i++)
+            {
+                messageBuilder.Append("Exception:");
+                messageBuilder.Append(i);
+
+                var formatter = _getExecptionFormatterCallback(exceptions.InnerExceptions[i]);
+                formatter.AppendFormattedMessage(exceptions.InnerExceptions[i], messageBuilder);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SFA.DAS.EAS.Infrastructure.Extensions;
+using System;
 using System.Text;
 
 namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
@@ -12,6 +13,19 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
             var exceptions = ((AggregateException)exception).Flatten();
 
             messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
+
+            var exceptionCount = 1;
+
+            foreach (var ex in exceptions.InnerExceptions)
+            {
+                messageBuilder.AppendLine($"Exception {exceptionCount}: ");
+
+                ex.AppendMessage(messageBuilder);
+
+                ex.InnerException?.AppendMessage(messageBuilder);
+
+                exceptionCount++;
+            }
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/AggregateExceptionMessageFormatter.cs
@@ -5,30 +5,13 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal class AggregateExceptionMessageFormatter : BaseExceptionMessageFormatter
     {
-
         public override Type SupportedException => typeof(AggregateException);
-
-        public AggregateExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback) : base(getExecptionFormatterCallback)
-        { }
 
         protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             var exceptions = ((AggregateException)exception).Flatten();
 
             messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
-
-            for (var i = 0; i < exceptions.InnerExceptions.Count; i++)
-            {
-                messageBuilder.AppendLine($"Exception: {i} ");
-
-                var formatter = _getExecptionFormatterCallback(exceptions.InnerExceptions[i]);
-                formatter.AppendFormattedMessage(exceptions.InnerExceptions[i], messageBuilder);
-            }
-        }
-
-        protected override void CreateInnerExceptionMessages(Exception exception, StringBuilder messageBuilder)
-        {
-            //We already handle inner exceptions above so we do not need to process them here
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
@@ -5,7 +5,13 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal abstract class BaseExceptionMessageFormatter : IExceptionMessageFormatter
     {
+        protected readonly Func<Exception, IExceptionMessageFormatter> _getExecptionFormatterCallback;
         public virtual Type SupportedException => typeof(Exception);
+
+        protected BaseExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback)
+        {
+            _getExecptionFormatterCallback = getExecptionFormatterCallback;
+        }
 
         public string GetFormattedMessage(Exception exception)
         {
@@ -16,6 +22,20 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
             return messageBuilder.ToString();
         }
 
-        public abstract void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder);
+        public void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            CreateFormattedMessage(exception, messageBuilder);
+            CreateInnerExceptionMessages(exception, messageBuilder);
+        }
+
+        protected abstract void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder);
+
+        protected virtual void CreateInnerExceptionMessages(Exception exception, StringBuilder messageBuilder)
+        {
+            if (exception.InnerException == null) return;
+
+            var messageFormatter = _getExecptionFormatterCallback(exception.InnerException);
+            messageFormatter.AppendFormattedMessage(exception.InnerException, messageBuilder);
+        }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
@@ -5,13 +5,7 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal abstract class BaseExceptionMessageFormatter : IExceptionMessageFormatter
     {
-        protected readonly Func<Exception, IExceptionMessageFormatter> _getExecptionFormatterCallback;
         public virtual Type SupportedException => typeof(Exception);
-
-        protected BaseExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getExecptionFormatterCallback)
-        {
-            _getExecptionFormatterCallback = getExecptionFormatterCallback;
-        }
 
         public string GetFormattedMessage(Exception exception)
         {
@@ -25,17 +19,8 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
         public void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             CreateFormattedMessage(exception, messageBuilder);
-            CreateInnerExceptionMessages(exception, messageBuilder);
         }
 
         protected abstract void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder);
-
-        protected virtual void CreateInnerExceptionMessages(Exception exception, StringBuilder messageBuilder)
-        {
-            if (exception.InnerException == null) return;
-
-            var messageFormatter = _getExecptionFormatterCallback(exception.InnerException);
-            messageFormatter.AppendFormattedMessage(exception.InnerException, messageBuilder);
-        }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/BaseExceptionMessageFormatter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
+{
+    internal abstract class BaseExceptionMessageFormatter : IExceptionMessageFormatter
+    {
+        public virtual Type SupportedException => typeof(Exception);
+
+        public string GetFormattedMessage(Exception exception)
+        {
+            var messageBuilder = new StringBuilder();
+
+            AppendFormattedMessage(exception, messageBuilder);
+
+            return messageBuilder.ToString();
+        }
+
+        public abstract void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder);
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SFA.DAS.EAS.Infrastructure.Extensions;
+using System;
 using System.Text;
 
 namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
@@ -15,6 +16,8 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
             {
                 messageBuilder.AppendLine($"Exception: {exception.GetType().Name}");
                 messageBuilder.AppendLine($"Message: {exception.Message}");
+
+                exception.InnerException?.AppendMessage(messageBuilder);
             }
         }
     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
@@ -5,11 +5,6 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal class ExceptionMessageFormatter : BaseExceptionMessageFormatter
     {
-        public ExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getFormatterCallback)
-            : base(getFormatterCallback)
-        {
-        }
-
         protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             if (exception == null)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
+{
+    internal class ExceptionMessageFormatter : BaseExceptionMessageFormatter
+    {
+        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            if (exception == null)
+            {
+                messageBuilder.Append("Exception is null");
+            }
+            else
+            {
+                messageBuilder.Append("Exception:");
+                messageBuilder.Append(exception.GetType().Name);
+                messageBuilder.Append(" Message:");
+                messageBuilder.Append(exception.Message);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/ExceptionMessageFormatter.cs
@@ -5,18 +5,21 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
 {
     internal class ExceptionMessageFormatter : BaseExceptionMessageFormatter
     {
-        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        public ExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getFormatterCallback)
+            : base(getFormatterCallback)
+        {
+        }
+
+        protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             if (exception == null)
             {
-                messageBuilder.Append("Exception is null");
+                messageBuilder.AppendLine("Exception is null");
             }
             else
             {
-                messageBuilder.Append("Exception:");
-                messageBuilder.Append(exception.GetType().Name);
-                messageBuilder.Append(" Message:");
-                messageBuilder.Append(exception.Message);
+                messageBuilder.AppendLine($"Exception: {exception.GetType().Name}");
+                messageBuilder.AppendLine($"Message: {exception.Message}");
             }
         }
     }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
@@ -8,18 +8,18 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
     {
         public override Type SupportedException => typeof(HttpException);
 
-        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        public HttpExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getFormatterCallback)
+        : base(getFormatterCallback)
+        { }
+
+        protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
             var httpException = exception as HttpException;
 
-            messageBuilder.Append("Exception: ");
-            messageBuilder.Append(httpException.GetType().Name);
-            messageBuilder.Append(" Message: ");
-            messageBuilder.Append(httpException.Message);
-            messageBuilder.Append(" HTTP-StatusCode:");
-            messageBuilder.Append(httpException.GetHttpCode());
-            messageBuilder.Append(" HTTP-Message:");
-            messageBuilder.Append(httpException.GetHtmlErrorMessage());
+            messageBuilder.AppendLine($"Exception: {httpException.GetType().Name}");
+            messageBuilder.AppendLine($"Message: {httpException.Message}");
+            messageBuilder.AppendLine($"HTTP-StatusCode: {httpException.GetHttpCode()}");
+            messageBuilder.Append($"HTTP-Message: {httpException.GetHtmlErrorMessage()}");
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SFA.DAS.EAS.Infrastructure.Extensions;
+using System;
 using System.Text;
 using System.Web;
 
@@ -16,6 +17,8 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
             messageBuilder.AppendLine($"Message: {httpException.Message}");
             messageBuilder.AppendLine($"HTTP-StatusCode: {httpException.GetHttpCode()}");
             messageBuilder.Append($"HTTP-Message: {httpException.GetHtmlErrorMessage()}");
+
+            exception.InnerException?.AppendMessage(messageBuilder);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text;
+using System.Web;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
+{
+    internal class HttpExceptionMessageFormatter : BaseExceptionMessageFormatter
+    {
+        public override Type SupportedException => typeof(HttpException);
+
+        public override void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder)
+        {
+            var httpException = exception as HttpException;
+
+            messageBuilder.Append("Exception: ");
+            messageBuilder.Append(httpException.GetType().Name);
+            messageBuilder.Append(" Message: ");
+            messageBuilder.Append(httpException.Message);
+            messageBuilder.Append(" HTTP-StatusCode:");
+            messageBuilder.Append(httpException.GetHttpCode());
+            messageBuilder.Append(" HTTP-Message:");
+            messageBuilder.Append(httpException.GetHtmlErrorMessage());
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/HttpExceptionMessageFormatter.cs
@@ -8,13 +8,9 @@ namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
     {
         public override Type SupportedException => typeof(HttpException);
 
-        public HttpExceptionMessageFormatter(Func<Exception, IExceptionMessageFormatter> getFormatterCallback)
-        : base(getFormatterCallback)
-        { }
-
         protected override void CreateFormattedMessage(Exception exception, StringBuilder messageBuilder)
         {
-            var httpException = exception as HttpException;
+            var httpException = (HttpException)exception;
 
             messageBuilder.AppendLine($"Exception: {httpException.GetType().Name}");
             messageBuilder.AppendLine($"Message: {httpException.Message}");

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/IExceptionMessageFormatter.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Exceptions/MessageFormatters/IExceptionMessageFormatter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Text;
+
+namespace SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters
+{
+    public interface IExceptionMessageFormatter
+    {
+        Type SupportedException { get; }
+        string GetFormattedMessage(Exception exception);
+        void AppendFormattedMessage(Exception exception, StringBuilder messageBuilder);
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
@@ -7,31 +7,6 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
 {
     public static class ExceptionExtensions
     {
-        //public class ExceptionTypeFormatter
-        //{
-        //    public ExceptionTypeFormatter(Type exceptionType, Action<Exception, StringBuilder> build)
-        //    {
-        //        Build = build;
-        //        SupportedException = exceptionType;
-        //    }
-
-        //    public Type SupportedException { get; }
-        //    public Action<Exception, StringBuilder> Build { get; }
-        //}
-
-        //private static readonly ConcurrentDictionary<Type, ExceptionTypeFormatter> ExceptionTypeFormatterCache = new ConcurrentDictionary<Type, ExceptionTypeFormatter>();
-
-        //private static readonly ExceptionTypeFormatter LastChanceFormatter = new ExceptionTypeFormatter(typeof(Exception), BuildLastChanceMessage);
-
-        //private static readonly ExceptionTypeFormatter[] ExceptionFormatters = new ExceptionTypeFormatter[]
-        //{
-        //    // This will catch all exceptions
-        //    new ExceptionTypeFormatter(typeof(Exception), BuildExceptionMessage),
-        //    new ExceptionTypeFormatter(typeof(AggregateException), BuildAggregateExceptionMessage),
-        //    new ExceptionTypeFormatter(typeof(HttpException), BuildHttpExceptionMessage)
-        //};
-
-
         public static string GetMessage(this Exception exception)
         {
             const int reasonableInitialMessageSize = 200;
@@ -41,8 +16,6 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
 
             messageFormatter.AppendFormattedMessage(exception, messageBuilder);
 
-            //BuildDetailedExceptionMessage(exception, messageBuilder);
-
             return messageBuilder.ToString();
         }
 
@@ -50,99 +23,5 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
         {
             return ExceptionMessageFormatterFactory.GetFormatter(exception);
         }
-
-        //private static void BuildDetailedExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        //{
-        //    if (exception == null)
-        //    {
-        //        return;
-        //    }
-
-        //    var handler = ExceptionTypeFormatterCache.GetOrAdd(exception.GetType(), GetAppropriateExceptionFormatter(exception));
-
-        //    handler.Build(exception, messageBuilder);
-
-        //    BuildDetailedExceptionMessage(exception.InnerException, messageBuilder);
-        //}
-
-        //public static ExceptionTypeFormatter GetAppropriateExceptionFormatter(Exception exception)
-        //{
-        //    ExceptionTypeFormatter result = null;
-
-        //    if (exception == null)
-        //    {
-        //        result = LastChanceFormatter;
-        //    }
-        //    else
-        //    {
-        //        var exceptionType = exception.GetType();
-
-        //        while (result == null)
-        //        {
-        //            // convert to dictionary
-        //            result = ExceptionFormatters.FirstOrDefault(ef => ef.SupportedException == exceptionType);
-        //            if (result == null)
-        //            {
-        //                if (exceptionType.BaseType == null)
-        //                {
-        //                    return LastChanceFormatter;
-        //                }
-
-        //                exceptionType = exceptionType.BaseType;
-        //            }
-        //        }
-        //    }
-
-        //    return result;
-        //}
-
-        //private static void BuildLastChanceMessage(Exception exception, StringBuilder messageBuilder)
-        //{
-        //    if (exception == null)
-        //    {
-        //        messageBuilder.Append("Exception is null");
-        //    }
-        //    else
-        //    {
-        //        messageBuilder.Append("Exception:");
-        //        messageBuilder.Append(exception.GetType().Name);
-        //        messageBuilder.Append(" Message:");
-        //        messageBuilder.Append(exception.Message);
-        //    }
-        //}
-
-        //private static void BuildExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        //{
-        //    messageBuilder.Append("Exception:");
-        //    messageBuilder.Append(exception.GetType().Name);
-        //    messageBuilder.Append(" Message:");
-        //    messageBuilder.Append(exception.Message);
-        //}
-
-        //private static void BuildAggregateExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        //{
-        //    var exceptions = ((AggregateException)exception).Flatten();
-
-        //    messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
-        //    for (int i = 0; i < exceptions.InnerExceptions.Count; i++)
-        //    {
-        //        messageBuilder.Append("Exception:");
-        //        messageBuilder.Append(i);
-        //        BuildDetailedExceptionMessage(exceptions.InnerExceptions[i], messageBuilder);
-        //    }
-        //}
-
-        //private static void BuildHttpExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        //{
-        //    var ex = (HttpException)exception;
-        //    messageBuilder.Append("Exception: ");
-        //    messageBuilder.Append(ex.GetType().Name);
-        //    messageBuilder.Append(" Message: ");
-        //    messageBuilder.Append(ex.Message);
-        //    messageBuilder.Append(" HTTP-StatusCode:");
-        //    messageBuilder.Append(ex.GetHttpCode());
-        //    messageBuilder.Append(" HTTP-Message:");
-        //    messageBuilder.Append(ex.GetHtmlErrorMessage());
-        //}
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
@@ -12,11 +12,20 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
             const int reasonableInitialMessageSize = 200;
             var messageBuilder = new StringBuilder(reasonableInitialMessageSize);
 
-            var messageFormatter = ExceptionMessageFormatterFactory.GetFormatter(exception);
+            var currentException = exception;
 
-            messageFormatter.AppendFormattedMessage(exception, messageBuilder);
+            while (currentException != null)
+            {
+                var messageFormatter = ExceptionMessageFormatterFactory.GetFormatter(exception);
 
-            return messageBuilder.ToString();
+                messageFormatter.AppendFormattedMessage(exception, messageBuilder);
+
+                currentException = currentException.InnerException;
+            }
+
+            var message = messageBuilder.ToString();
+
+            return message;
         }
 
         public static IExceptionMessageFormatter GetAppropriateExceptionFormatter(Exception exception)

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
@@ -1,36 +1,35 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Linq;
+﻿using SFA.DAS.EAS.Infrastructure.Exceptions;
+using SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters;
+using System;
 using System.Text;
-using System.Web;
 
 namespace SFA.DAS.EAS.Infrastructure.Extensions
 {
     public static class ExceptionExtensions
     {
-        public class ExceptionTypeFormatter 
-        {
-            public ExceptionTypeFormatter(Type exceptionType, Action<Exception, StringBuilder> build)
-            {
-                Build = build;
-                SupportedException = exceptionType;
-            }
+        //public class ExceptionTypeFormatter
+        //{
+        //    public ExceptionTypeFormatter(Type exceptionType, Action<Exception, StringBuilder> build)
+        //    {
+        //        Build = build;
+        //        SupportedException = exceptionType;
+        //    }
 
-            public Type SupportedException { get; }
-            public Action<Exception, StringBuilder> Build { get; }
-        }
+        //    public Type SupportedException { get; }
+        //    public Action<Exception, StringBuilder> Build { get; }
+        //}
 
-        private static readonly ConcurrentDictionary<Type, ExceptionTypeFormatter> ExceptionTypeFormatterCache = new ConcurrentDictionary<Type, ExceptionTypeFormatter>();
+        //private static readonly ConcurrentDictionary<Type, ExceptionTypeFormatter> ExceptionTypeFormatterCache = new ConcurrentDictionary<Type, ExceptionTypeFormatter>();
 
-        private static readonly ExceptionTypeFormatter LastChanceFormatter = new ExceptionTypeFormatter(typeof(Exception), BuildLastChanceMessage);
+        //private static readonly ExceptionTypeFormatter LastChanceFormatter = new ExceptionTypeFormatter(typeof(Exception), BuildLastChanceMessage);
 
-        private static readonly ExceptionTypeFormatter[] ExceptionFormatters = new ExceptionTypeFormatter[]
-        {
-            // This will catch all exceptions
-            new ExceptionTypeFormatter(typeof(Exception), BuildExceptionMessage),
-            new ExceptionTypeFormatter(typeof(AggregateException), BuildAggregateExceptionMessage),
-            new ExceptionTypeFormatter(typeof(HttpException), BuildHttpExceptionMessage) 
-        };
+        //private static readonly ExceptionTypeFormatter[] ExceptionFormatters = new ExceptionTypeFormatter[]
+        //{
+        //    // This will catch all exceptions
+        //    new ExceptionTypeFormatter(typeof(Exception), BuildExceptionMessage),
+        //    new ExceptionTypeFormatter(typeof(AggregateException), BuildAggregateExceptionMessage),
+        //    new ExceptionTypeFormatter(typeof(HttpException), BuildHttpExceptionMessage)
+        //};
 
 
         public static string GetMessage(this Exception exception)
@@ -38,103 +37,112 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
             const int reasonableInitialMessageSize = 200;
             var messageBuilder = new StringBuilder(reasonableInitialMessageSize);
 
-            BuildDetailedExceptionMessage(exception, messageBuilder);
+            var messageFormatter = ExceptionMessageFormatterFactory.GetFormatter(exception);
+
+            messageFormatter.AppendFormattedMessage(exception, messageBuilder);
+
+            //BuildDetailedExceptionMessage(exception, messageBuilder);
 
             return messageBuilder.ToString();
         }
 
-        private static void BuildDetailedExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        public static IExceptionMessageFormatter GetAppropriateExceptionFormatter(Exception exception)
         {
-            if (exception == null)
-            {
-                return;
-            }
-
-            var handler = ExceptionTypeFormatterCache.GetOrAdd(exception.GetType(), GetAppropriateExceptionFormatter(exception));
-
-            handler.Build(exception, messageBuilder);
-
-            BuildDetailedExceptionMessage(exception.InnerException, messageBuilder);
+            return ExceptionMessageFormatterFactory.GetFormatter(exception);
         }
 
-        public static ExceptionTypeFormatter GetAppropriateExceptionFormatter(Exception exception)
-        {
-            ExceptionTypeFormatter result = null;
+        //private static void BuildDetailedExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        //{
+        //    if (exception == null)
+        //    {
+        //        return;
+        //    }
 
-            if (exception == null)
-            {
-                result = LastChanceFormatter;
-            }
-            else
-            {
-                var exceptionType = exception.GetType();
+        //    var handler = ExceptionTypeFormatterCache.GetOrAdd(exception.GetType(), GetAppropriateExceptionFormatter(exception));
 
-                while (result == null)
-                {
-                    // convert to dictionary
-                    result = ExceptionFormatters.FirstOrDefault(ef => ef.SupportedException == exceptionType);
-                    if (result == null)
-                    {
-                        if (exceptionType.BaseType == null)
-                        {
-                            return LastChanceFormatter;
-                        }
+        //    handler.Build(exception, messageBuilder);
 
-                        exceptionType = exceptionType.BaseType;
-                    }
-                }
-            }
+        //    BuildDetailedExceptionMessage(exception.InnerException, messageBuilder);
+        //}
 
-            return result;
-        }
+        //public static ExceptionTypeFormatter GetAppropriateExceptionFormatter(Exception exception)
+        //{
+        //    ExceptionTypeFormatter result = null;
 
-        private static void BuildLastChanceMessage(Exception exception, StringBuilder messageBuilder)
-        {
-            if (exception == null)
-            {
-                messageBuilder.Append("Exception is null");
-            }
-            else
-            { 
-                messageBuilder.Append("Exception:");
-                messageBuilder.Append(exception.GetType().Name);
-                messageBuilder.Append(" Message:");
-                messageBuilder.Append(exception.Message);
-            }
-        }
+        //    if (exception == null)
+        //    {
+        //        result = LastChanceFormatter;
+        //    }
+        //    else
+        //    {
+        //        var exceptionType = exception.GetType();
 
-        private static void BuildExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        {
-            messageBuilder.Append("Exception:");
-            messageBuilder.Append(exception.GetType().Name);
-            messageBuilder.Append(" Message:");
-            messageBuilder.Append(exception.Message);
-        }
+        //        while (result == null)
+        //        {
+        //            // convert to dictionary
+        //            result = ExceptionFormatters.FirstOrDefault(ef => ef.SupportedException == exceptionType);
+        //            if (result == null)
+        //            {
+        //                if (exceptionType.BaseType == null)
+        //                {
+        //                    return LastChanceFormatter;
+        //                }
 
-        private static void BuildAggregateExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        {
-            var exceptions = ((AggregateException) exception).Flatten();
+        //                exceptionType = exceptionType.BaseType;
+        //            }
+        //        }
+        //    }
 
-            messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
-            for (int i = 0; i < exceptions.InnerExceptions.Count; i++)
-            {
-                messageBuilder.Append("Exception:");
-                messageBuilder.Append(i);
-                BuildDetailedExceptionMessage(exceptions.InnerExceptions[i], messageBuilder);
-            }
-        }
+        //    return result;
+        //}
 
-        private static void BuildHttpExceptionMessage(Exception exception, StringBuilder messageBuilder)
-        {
-            var ex = (HttpException) exception;
-            messageBuilder.Append("Exception: ");
-            messageBuilder.Append(ex.GetType().Name);
-            messageBuilder.Append(" Message: ");
-            messageBuilder.Append(ex.Message);
-            messageBuilder.Append(" HTTP-StatusCode:");
-            messageBuilder.Append(ex.GetHttpCode());
-            messageBuilder.Append(" HTTP-Message:");
-            messageBuilder.Append(ex.GetHtmlErrorMessage());
-        }  
+        //private static void BuildLastChanceMessage(Exception exception, StringBuilder messageBuilder)
+        //{
+        //    if (exception == null)
+        //    {
+        //        messageBuilder.Append("Exception is null");
+        //    }
+        //    else
+        //    {
+        //        messageBuilder.Append("Exception:");
+        //        messageBuilder.Append(exception.GetType().Name);
+        //        messageBuilder.Append(" Message:");
+        //        messageBuilder.Append(exception.Message);
+        //    }
+        //}
+
+        //private static void BuildExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        //{
+        //    messageBuilder.Append("Exception:");
+        //    messageBuilder.Append(exception.GetType().Name);
+        //    messageBuilder.Append(" Message:");
+        //    messageBuilder.Append(exception.Message);
+        //}
+
+        //private static void BuildAggregateExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        //{
+        //    var exceptions = ((AggregateException)exception).Flatten();
+
+        //    messageBuilder.AppendLine($"Aggregate exception has {exceptions.InnerExceptions.Count} inner exception.");
+        //    for (int i = 0; i < exceptions.InnerExceptions.Count; i++)
+        //    {
+        //        messageBuilder.Append("Exception:");
+        //        messageBuilder.Append(i);
+        //        BuildDetailedExceptionMessage(exceptions.InnerExceptions[i], messageBuilder);
+        //    }
+        //}
+
+        //private static void BuildHttpExceptionMessage(Exception exception, StringBuilder messageBuilder)
+        //{
+        //    var ex = (HttpException)exception;
+        //    messageBuilder.Append("Exception: ");
+        //    messageBuilder.Append(ex.GetType().Name);
+        //    messageBuilder.Append(" Message: ");
+        //    messageBuilder.Append(ex.Message);
+        //    messageBuilder.Append(" HTTP-StatusCode:");
+        //    messageBuilder.Append(ex.GetHttpCode());
+        //    messageBuilder.Append(" HTTP-Message:");
+        //    messageBuilder.Append(ex.GetHtmlErrorMessage());
+        //}
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/Extensions/ExceptionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using SFA.DAS.EAS.Infrastructure.Exceptions;
 using SFA.DAS.EAS.Infrastructure.Exceptions.MessageFormatters;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace SFA.DAS.EAS.Infrastructure.Extensions
@@ -19,23 +17,14 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
             return messageBuilder.ToString();
         }
 
+        public static void AppendMessage(this Exception exception, StringBuilder messageBuilder)
+        {
+            GetExceptionMessage(exception, messageBuilder);
+        }
+
         public static IExceptionMessageFormatter GetAppropriateExceptionFormatter(Exception exception)
         {
             return ExceptionMessageFormatterFactory.GetFormatter(exception);
-        }
-
-        public static IEnumerable<Exception> GetInnerExceptions(this Exception exception)
-        {
-            if (exception.InnerException == null) return new Exception[0];
-
-            if (exception.GetType() != typeof(AggregateException))
-            {
-                return new[] { exception.InnerException };
-            }
-
-            var exceptions = ((AggregateException)exception).Flatten();
-
-            return exceptions.InnerExceptions;
         }
 
         private static void GetExceptionMessage(Exception exception, StringBuilder messageBuilder)
@@ -43,20 +32,6 @@ namespace SFA.DAS.EAS.Infrastructure.Extensions
             var messageFormatter = ExceptionMessageFormatterFactory.GetFormatter(exception);
 
             messageFormatter.AppendFormattedMessage(exception, messageBuilder);
-
-            var innerExceptions = exception.GetInnerExceptions().ToArray();
-
-            var hasMultipleInnerExceptions = innerExceptions.Length > 1;
-
-            for (var index = 0; index < innerExceptions.Length; index++)
-            {
-                if (hasMultipleInnerExceptions)
-                {
-                    messageBuilder.AppendLine($"Exception: {index}");
-                }
-
-                GetExceptionMessage(innerExceptions[index], messageBuilder);
-            }
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
@@ -280,6 +280,12 @@
     <Compile Include="DependencyResolution\CurrentDatePolicy.cs" />
     <Compile Include="DependencyResolution\Environment.cs" />
     <Compile Include="DependencyResolution\ExecutionPolicyPolicy.cs" />
+    <Compile Include="Exceptions\ExceptionMessageFormatterFactory.cs" />
+    <Compile Include="Exceptions\MessageFormatters\AggregateExceptionMessageFormatter.cs" />
+    <Compile Include="Exceptions\MessageFormatters\BaseExceptionMessageFormatter.cs" />
+    <Compile Include="Exceptions\MessageFormatters\ExceptionMessageFormatter.cs" />
+    <Compile Include="Exceptions\MessageFormatters\HttpExceptionMessageFormatter.cs" />
+    <Compile Include="Exceptions\MessageFormatters\IExceptionMessageFormatter.cs" />
     <Compile Include="ExecutionPolicies\CompaniesHouseExecutionPolicy.cs" />
     <Compile Include="ExecutionPolicies\ExecutionPolicy.cs" />
     <Compile Include="ExecutionPolicies\HmrcExecutionPolicy.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Infrastructure/SFA.DAS.EAS.Infrastructure.csproj
@@ -288,6 +288,7 @@
     <Compile Include="ExecutionPolicies\RequiredPolicyAttribute.cs" />
     <Compile Include="Extensions\EmployerFinancialDbContextExtensions.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Extensions\PaymentDetailsExtensions.cs" />
     <Compile Include="Extensions\HashingServiceExtensions.cs" />
     <Compile Include="Extensions\QueryableExtensions.cs" />

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
@@ -2,6 +2,7 @@ using Microsoft.WindowsAzure.ServiceRuntime;
 using SFA.DAS.EAS.Application.DependencyResolution;
 using SFA.DAS.EAS.Domain.Configuration;
 using SFA.DAS.EAS.Infrastructure.DependencyResolution;
+using SFA.DAS.EAS.Infrastructure.Extensions;
 using SFA.DAS.EAS.Infrastructure.Logging;
 using SFA.DAS.EAS.LevyDeclarationProvider.Worker.DependencyResolution;
 using SFA.DAS.EAS.LevyDeclarationProvider.Worker.Providers;
@@ -9,6 +10,7 @@ using SFA.DAS.Messaging.AzureServiceBus;
 using SFA.DAS.Messaging.AzureServiceBus.StructureMap;
 using SFA.DAS.NLog.Logger;
 using StructureMap;
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
@@ -17,6 +19,8 @@ namespace SFA.DAS.EAS.LevyDeclarationProvider.Worker
 {
     public class WorkerRole : RoleEntryPoint
     {
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly ManualResetEvent _runCompleteEvent = new ManualResetEvent(false);
         private IContainer _container;
@@ -31,6 +35,11 @@ namespace SFA.DAS.EAS.LevyDeclarationProvider.Worker
             {
                 var levyDeclaration = _container.GetInstance<ILevyDeclaration>();
                 levyDeclaration.RunAsync(_cancellationTokenSource.Token).Wait();
+            }
+            catch (Exception ex)
+            {
+                Logger.Fatal(ex, ex.GetMessage());
+                throw;
             }
             finally
             {

--- a/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
+++ b/src/SFA.DAS.LevyDeclarationProvider.Worker/WorkerRole.cs
@@ -1,14 +1,10 @@
 using Microsoft.WindowsAzure.ServiceRuntime;
+using NLog;
 using SFA.DAS.EAS.Application.DependencyResolution;
-using SFA.DAS.EAS.Domain.Configuration;
-using SFA.DAS.EAS.Infrastructure.DependencyResolution;
 using SFA.DAS.EAS.Infrastructure.Extensions;
 using SFA.DAS.EAS.Infrastructure.Logging;
 using SFA.DAS.EAS.LevyDeclarationProvider.Worker.DependencyResolution;
 using SFA.DAS.EAS.LevyDeclarationProvider.Worker.Providers;
-using SFA.DAS.Messaging.AzureServiceBus;
-using SFA.DAS.Messaging.AzureServiceBus.StructureMap;
-using SFA.DAS.NLog.Logger;
 using StructureMap;
 using System;
 using System.Diagnostics;


### PR DESCRIPTION
This replaces the GetMessage() exception helper with an implementation that can deal with specific exception types.