### PR TITLE
AML-2183 Page Not Found When Registering

### DIFF
--- a/src/SFA.DAS.EAS.Web/Authentication/OwinAuthenticationService.cs
+++ b/src/SFA.DAS.EAS.Web/Authentication/OwinAuthenticationService.cs
@@ -71,6 +71,18 @@ namespace SFA.DAS.EAS.Web.Authentication
                     identity.AddClaim(new Claim("email", claim.Item2));
                     identity.AddClaim(new Claim(DasClaimTypes.Email, claim.Item2));   
                 }
+
+                if (claim.Item1.Equals(DasClaimTypes.RequiresVerification))
+                {
+                    var requiresValidationClaim =
+                        identity.Claims.FirstOrDefault(c => c.Type == DasClaimTypes.RequiresVerification);
+
+                    if (requiresValidationClaim != null)
+                    {
+                        identity.RemoveClaim(requiresValidationClaim);
+                    }
+                    identity.AddClaim(new Claim(DasClaimTypes.RequiresVerification, claim.Item2));
+                }
             }
         }
     }

--- a/src/SFA.DAS.EAS.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using System.Web.Mvc;
 using SFA.DAS.EAS.Domain.Configuration;
 using SFA.DAS.EAS.Domain.Interfaces;
 using SFA.DAS.EAS.Infrastructure.Authorization;
+using SFA.DAS.EAS.Web.Attributes;
 using SFA.DAS.EAS.Web.Helpers;
 using SFA.DAS.EAS.Web.Orchestrators;
 using SFA.DAS.EAS.Web.ViewModels;
@@ -37,9 +38,8 @@ namespace SFA.DAS.EAS.Web.Controllers
             var userId = OwinWrapper.GetClaimValue(ControllerConstants.UserExternalIdClaimKeyName);
             if (!string.IsNullOrWhiteSpace(userId))
             {
-
+                await OwinWrapper.UpdateClaims();
                 var partialLogin = OwinWrapper.GetClaimValue(DasClaimTypes.RequiresVerification);
-
                 if (partialLogin.Equals("true", StringComparison.CurrentCultureIgnoreCase))
                 {
                     return Redirect(ConfigurationFactory.Current.Get().AccountActivationUrl);
@@ -153,8 +153,9 @@ namespace SFA.DAS.EAS.Web.Controllers
         [Authorize]
         [HttpGet]
         [Route("register/new")]
-        public ActionResult HandleNewRegistration()
+        public async Task<ActionResult> HandleNewRegistration()
         {
+            await OwinWrapper.UpdateClaims();
             return RedirectToAction(ControllerConstants.IndexActionName);
         }
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIHandleNewRegistration.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIHandleNewRegistration.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EAS.Domain.Configuration;
+using SFA.DAS.EAS.Domain.Interfaces;
+using SFA.DAS.EAS.Infrastructure.Authentication;
+using SFA.DAS.EAS.Infrastructure.Authorization;
+using SFA.DAS.EAS.Web.Controllers;
+using SFA.DAS.EAS.Web.Orchestrators;
+using SFA.DAS.EAS.Web.ViewModels;
+
+namespace SFA.DAS.EAS.Web.UnitTests.Controllers.HomeControllerTests
+{
+    public class WhenIHandleNewRegistration
+    {
+        private Mock<IAuthenticationService> _owinWrapper;
+        private HomeController _homeController;
+        private EmployerApprenticeshipsServiceConfiguration _configuration;
+        private string ExpectedUserId = "123ABC";
+
+        [SetUp]
+        public void Arrange()
+        {
+            _owinWrapper = new Mock<IAuthenticationService>();
+            _configuration = new EmployerApprenticeshipsServiceConfiguration();
+
+            _homeController = new HomeController(
+                _owinWrapper.Object, Mock.Of<HomeOrchestrator>(), _configuration, Mock.Of<IAuthorizationService>(),
+                Mock.Of<IMultiVariantTestingService>(), Mock.Of<ICookieStorageService<FlashMessageViewModel>>());
+        }
+
+
+        [Test]
+        public async Task ThenTheClaimsAreRefreshedForThatUserWhenAuthenticated()
+        {
+            //Arrange
+            _owinWrapper.Setup(x => x.GetClaimValue("sub")).Returns(ExpectedUserId);
+
+            //Act
+            await _homeController.HandleNewRegistration();
+
+            //Assert
+            _owinWrapper.Verify(x => x.UpdateClaims(), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIModifyMyUserAccount.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIModifyMyUserAccount.cs
@@ -81,10 +81,10 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.HomeControllerTests
         }
 
         [Test]
-        public void ThenTheAccountCreatedActionCreatesARedirectToRouteResultToTheIndex()
+        public async Task ThenTheAccountCreatedActionCreatesARedirectToRouteResultToTheIndex()
         {
             //Act
-            var actual = _homeController.HandleNewRegistration();
+            var actual = await _homeController.HandleNewRegistration();
 
             //Assert
             Assert.IsNotNull(actual);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIViewTheHomePage.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Controllers/HomeControllerTests/WhenIViewTheHomePage.cs
@@ -116,6 +116,19 @@ namespace SFA.DAS.EAS.Web.UnitTests.Controllers.HomeControllerTests
         }
 
         [Test]
+        public async Task ThenTheClaimsAreRefreshedForThatUserWhenAuthenticated()
+        {
+            //Arrange
+            _owinWrapper.Setup(x => x.GetClaimValue("sub")).Returns(ExpectedUserId);
+
+            //Act
+            await _homeController.Index();
+
+            //Assert
+            _owinWrapper.Verify(x => x.UpdateClaims(), Times.Once);
+        }
+
+        [Test]
         public void ThenTheIndexDoesNotHaveTheAuthorizeAttribute()
         {
             var methods = typeof(HomeController).GetMethods().Where(m => m.Name.Equals("Index")).ToList();

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EAS.Web.UnitTests.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Controllers\EmployerAccountTransactionsControllerTests\WhenIViewTransactions.cs" />
     <Compile Include="Controllers\EmployerAgreementControllerTests.cs" />
     <Compile Include="Controllers\EmployerTeamControllerTests\WhenIViewNextSteps.cs" />
+    <Compile Include="Controllers\HomeControllerTests\WhenIHandleNewRegistration.cs" />
     <Compile Include="Controllers\InvitationControllerTests\WhenIAcceptAnInvitation.cs" />
     <Compile Include="Controllers\OrganisationControllerTests\WhenIConfirmAddOfOrganisation.cs" />
     <Compile Include="Controllers\OrganisationSharedTests\OrganisationSharedControllerTestBase.cs" />


### PR DESCRIPTION
Hard to Test! 

When you register a new user for the service, there is a step where you are asked to enter a code that has been emailed to you.
Do not close the browser at this point and you navigate to the link in the email (which takes you via another url back to the confirm page you were just on). 
Now enter the code in the email and you end up with "Page Not Found".

If you do not use the URL in the email you do not get this issue. If you log out and close browsers you do not get this issue.

After investigation I found a discrepancy in the claims, when using the link, so I have added some code that refreshes the claims any time "RequiresVerifiaction" is used, and now it navigates to the "Set up your account" page at the end of the process.

I have tried to implement this using attributes but ran into thread deadlocks, or threads completing in wrong context issues when calling async from synchronous action attributes, so I left it this way!