### PR TITLE
Fix to avoid endless loop in downloading transactions when the API throws and exception

### DIFF
--- a/src/SFA.DAS.EAS.Support.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.EAS.Support.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -19,13 +19,13 @@
     <AddressAssignments>
       <InstanceAddress roleName="SFA.DAS.EAS.Support.Web">
         <Subnets>
-          <Subnet name="__subnet__" />
+          <Subnet name="__subnet2__" />
         </Subnets>
       </InstanceAddress>
     </AddressAssignments>
     <LoadBalancers>
-      <LoadBalancer name="__ilbname__">
-        <FrontendIPConfiguration type="private" subnet="__subnet__" staticVirtualNetworkIPAddress="10.78.124.243" />
+      <LoadBalancer name="__ilbnamesupport__">
+        <FrontendIPConfiguration type="private" subnet="__subnet2__" staticVirtualNetworkIPAddress="10.78.124.243" />
       </LoadBalancer>
     </LoadBalancers>
   </NetworkConfiguration>

--- a/src/SFA.DAS.EAS.Support.Infrastructure.Tests/AccountRepository/WhenCallingGetWithAccountFieldsSelectionFinance.cs
+++ b/src/SFA.DAS.EAS.Support.Infrastructure.Tests/AccountRepository/WhenCallingGetWithAccountFieldsSelectionFinance.cs
@@ -137,5 +137,120 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Tests.AccountRepository
             Assert.IsNull(actual.LegalEntities);
             Assert.IsNull(actual.TeamMembers);
         }
+
+
+        [Test]
+        public async Task ItShouldReturnZeroAccountTransactionsIfTheApiThrowsAnException()
+        {
+            var id = "123";
+
+            var accountDetailViewModel = new AccountDetailViewModel
+            {
+                AccountId = 123,
+                Balance = 0m,
+                PayeSchemes = new ResourceList(
+                    new List<ResourceViewModel>
+                    {
+                        new ResourceViewModel
+                        {
+                            Id = "123/123456",
+                            Href = "https://tempuri.org/payescheme/{1}"
+                        }
+                    }),
+                LegalEntities = new ResourceList(
+                    new List<ResourceViewModel>
+                    {
+                        new ResourceViewModel
+                        {
+                            Id = "TempUri Limited",
+                            Href = "https://tempuri.org/organisation/{1}"
+                        }
+                    }),
+
+                HashedAccountId = "DFGH",
+                DateRegistered = DateTime.Today.AddYears(-2),
+                OwnerEmail = "Owner@tempuri.org",
+                DasAccountName = "Test Account 1"
+            };
+
+            AccountApiClient.Setup(x => x.GetResource<AccountDetailViewModel>($"/api/accounts/{id}"))
+                .ReturnsAsync(accountDetailViewModel);
+
+            var obscuredPayePayeScheme = "123/123456";
+
+            PayeSchemeObfuscator.Setup(x => x.ObscurePayeScheme(It.IsAny<string>()))
+                .Returns(obscuredPayePayeScheme);
+
+
+            var payeSchemeViewModel = new PayeSchemeViewModel
+            {
+                AddedDate = DateTime.Today.AddMonths(-4),
+                Ref = "123/123456",
+                Name = "123/123456",
+                DasAccountId = "123",
+                RemovedDate = null
+            };
+
+            AccountApiClient.Setup(x => x.GetResource<PayeSchemeViewModel>(It.IsAny<string>()))
+                .ReturnsAsync(payeSchemeViewModel);
+
+
+            /* 
+             * This is a testing HACK to avoid using a concrete datetime service
+             * because our collegues used DateTime.Now in the code! 
+             * See ASCS-83 for a fix
+             */
+            var now = DateTime.Now.Date;
+            var startOfFirstFinancialYear = new DateTime(2017, 4, 1);
+            var monthsToQuery = (now.Year - startOfFirstFinancialYear.Year) * 12 +
+                                (now.Month - startOfFirstFinancialYear.Month) + 1;
+
+            DatetimeService.Setup(x => x.GetBeginningFinancialYear(startOfFirstFinancialYear))
+                .Returns(startOfFirstFinancialYear);
+
+
+            var isNotZero = 100m;
+            var isTxDateCreated = DateTime.Today;
+            var transactionsViewModel = new TransactionsViewModel
+            {
+                new TransactionViewModel
+                {
+                    Description = "Is Not Null",
+                    Amount = isNotZero,
+                    DateCreated = isTxDateCreated
+                },
+                new TransactionViewModel
+                {
+                    Description = "Is Not Null 2",
+                    Amount = isNotZero,
+                    DateCreated = isTxDateCreated
+                }
+            };
+
+            AccountApiClient.Setup(x => x.GetTransactions(accountDetailViewModel.HashedAccountId,
+                    It.IsAny<int>(),
+                    It.IsAny<int>()))
+                .ThrowsAsync(new Exception("Waaaaaaaah"));
+
+            var actual = await _sut.Get(id, AccountFieldsSelection.Finance);
+
+            Logger.Verify(x => x.Debug(It.IsAny<string>()), Times.Exactly(2));
+
+            PayeSchemeObfuscator
+                .Verify(x => x.ObscurePayeScheme(It.IsAny<string>()), Times.Exactly(2));
+
+            AccountApiClient
+                .Verify(x => x.GetTransactions(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+                    Times.Exactly(monthsToQuery));
+
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(actual.PayeSchemes);
+            Assert.AreEqual(1, actual.PayeSchemes.Count());
+            Assert.IsNotNull(actual.Transactions);
+            Assert.AreEqual(0, actual.Transactions.Count());
+
+            Assert.IsNull(actual.LegalEntities);
+            Assert.IsNull(actual.TeamMembers);
+        }
     }
 }

--- a/src/SFA.DAS.EAS.Support.Infrastructure/Services/AccountRepository.cs
+++ b/src/SFA.DAS.EAS.Support.Infrastructure/Services/AccountRepository.cs
@@ -70,7 +70,7 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Services
             }
             catch (Exception e)
             {
-                _logger.Error(e,$"A general exception has been thrown while requesting employer account details");
+                _logger.Error(e, $"A general exception has been thrown while requesting employer account details");
             }
 
             return results;
@@ -162,8 +162,8 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Services
 
         private async Task<List<TransactionViewModel>> GetAccountTransactions(string accountId)
         {
-            var endDate = DateTime.Now;
-            var financialYearIterator = _datetimeService.GetBeginningFinancialYear(endDate);
+            var endDate = DateTime.Now.Date;
+            var financialYearIterator = _datetimeService.GetBeginningFinancialYear(new DateTime(2017, 4, 1));
             var response = new List<TransactionViewModel>();
 
             while (financialYearIterator <= endDate)
@@ -172,14 +172,13 @@ namespace SFA.DAS.EAS.Support.Infrastructure.Services
                 {
                     var transactions = await _accountApiClient.GetTransactions(accountId, financialYearIterator.Year,
                         financialYearIterator.Month);
-
                     response.AddRange(transactions);
-                    financialYearIterator = financialYearIterator.AddMonths(1);
                 }
                 catch (Exception e)
                 {
                     _logger.Error(e, $"Exception occured in Account API type of {nameof(TransactionsViewModel)} for period {financialYearIterator.Year}.{financialYearIterator.Month} id {accountId}");
                 }
+                financialYearIterator = financialYearIterator.AddMonths(1);
             }
 
             return GetFilteredTransactions(response);


### PR DESCRIPTION
This is a retro-fit from the legacy repo and is already deployed into the live environment. It ensures the current code base matches that which is already deployed to PROD. A regression test for MA is required, and a regression for Support is required to test it.