### PR TITLE
aml-2239-Account-History-Unique-Index-For-Null-RemovedDates

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Account.Database/Tables/AccountHistory.sql
+++ b/src/SFA.DAS.EAS.Employer_Account.Database/Tables/AccountHistory.sql
@@ -11,3 +11,4 @@ GO
 CREATE INDEX [IDX_AccountHistory_Account] on [employer_account].[AccountHistory] (AccountId, PayeRef)
 GO
 CREATE UNIQUE NONCLUSTERED INDEX [IDX_UNIQUE_AccountHistory_Account_Paye] on [employer_account].[AccountHistory] (AccountId, PayeRef)
+WHERE RemovedDate IS NULL


### PR DESCRIPTION
Just makes sure the index is only applied to rows with a null Removed Date