### PR TITLE
AML-2666 Fix RemoveLegalEntityMessage to set the CreatorName

### DIFF
--- a/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RemoveLegalEntity/RemoveLegalEntityCommand.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Application/Commands/RemoveLegalEntity/RemoveLegalEntityCommand.cs
@@ -5,6 +5,14 @@ namespace SFA.DAS.EAS.Application.Commands.RemoveLegalEntity
     public class RemoveLegalEntityCommand : IAsyncRequest
     {
         public string HashedAccountId { get; set; }
+
+        /// <summary>
+        ///     The UserRef of the user.
+        /// </summary>
+        /// <remarks>
+        ///     This is not the Id of the user. Not renaming it as UserId seems to be used 
+        ///     comprehensively for UserRef.
+        /// </remarks>
         public string UserId { get; set; }
         public string HashedLegalAgreementId { get; set; }
     }


### PR DESCRIPTION
Set the creator name to be the logged in user rather than the agreement signatory.