### PR TITLE
AML-2831

### DIFF
--- a/src/SFA.DAS.EmployerAccounts/Configuration/EmployerAccountsConfiguration.cs
+++ b/src/SFA.DAS.EmployerAccounts/Configuration/EmployerAccountsConfiguration.cs
@@ -25,5 +25,6 @@ namespace SFA.DAS.EmployerAccounts.Configuration
         public string PublicAllowedAccountLegalEntityHashstringSalt { get; set; }
         public string PublicHashstring { get; set; }
         public string ServiceBusConnectionString { get; set; }
+        public string RedisConnection { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerAccounts/DependencyResolution/CachesRegistry.cs
+++ b/src/SFA.DAS.EmployerAccounts/DependencyResolution/CachesRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using SFA.DAS.Caches;
 using SFA.DAS.Configuration;
+using SFA.DAS.EmployerAccounts.Configuration;
 using StructureMap;
 
 namespace SFA.DAS.EmployerAccounts.DependencyResolution
@@ -16,7 +17,8 @@ namespace SFA.DAS.EmployerAccounts.DependencyResolution
             }
             else
             {
-                For<IDistributedCache>().Use<RedisCache>().Singleton();
+                For<IDistributedCache>().Use<RedisCache>(c =>
+                    new RedisCache(c.GetInstance<EmployerAccountsConfiguration>().RedisConnection)).Singleton();
             }
         }
     }

--- a/src/SFA.DAS.EmployerFinance/Configuration/EmployerFinanceConfiguration.cs
+++ b/src/SFA.DAS.EmployerFinance/Configuration/EmployerFinanceConfiguration.cs
@@ -1,5 +1,9 @@
-﻿using SFA.DAS.Authentication;
+﻿using System;
+using System.Linq.Expressions;
+using SFA.DAS.Authentication;
+using SFA.DAS.Caches;
 using SFA.DAS.Messaging.AzureServiceBus.StructureMap;
+using StructureMap;
 
 namespace SFA.DAS.EmployerFinance.Configuration
 {
@@ -25,5 +29,6 @@ namespace SFA.DAS.EmployerFinance.Configuration
         public string PublicAllowedHashstringCharacters { get; set; }
         public string PublicHashstring { get; set; }
         public string ServiceBusConnectionString { get; set; }
+        public string RedisConnection { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerFinance/DependencyResolution/CachesRegistry.cs
+++ b/src/SFA.DAS.EmployerFinance/DependencyResolution/CachesRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using SFA.DAS.Caches;
 using SFA.DAS.Configuration;
+using SFA.DAS.EmployerFinance.Configuration;
 using StructureMap;
 
 namespace SFA.DAS.EmployerFinance.DependencyResolution
@@ -16,7 +17,9 @@ namespace SFA.DAS.EmployerFinance.DependencyResolution
             }
             else
             {
-                For<IDistributedCache>().Use<RedisCache>().Singleton();
+                For<IDistributedCache>().Use<RedisCache>(c=> 
+                    new RedisCache(c.GetInstance<EmployerFinanceConfiguration>().RedisConnection))
+                    .Singleton();
             }
         }
     }


### PR DESCRIPTION
Implemented Changes to get RedisConnection information to RedisCache startup from Azure Storage Table configuration. This change requires PR https://github.com/SkillsFundingAgency/das-employer-config/pull/115 to be implemented. in the cloud, or checking out AML-2831 from das-employer-config checkout AML-2831 and run the config updater.