### PR TITLE
AML-3079 Fixed User Invite Activity Text - Invited User Name

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.UnitTests/Commands/CreateInvitationTests/WhenICallCreateInvitation.cs
+++ b/src/SFA.DAS.EmployerAccounts.UnitTests/Commands/CreateInvitationTests/WhenICallCreateInvitation.cs
@@ -10,6 +10,7 @@ using SFA.DAS.EmployerAccounts.Commands.CreateInvitation;
 using SFA.DAS.EmployerAccounts.Commands.SendNotification;
 using SFA.DAS.EmployerAccounts.Configuration;
 using SFA.DAS.EmployerAccounts.Data;
+using SFA.DAS.EmployerAccounts.Messages.Events;
 using SFA.DAS.EmployerAccounts.Models.AccountTeam;
 using SFA.DAS.EmployerAccounts.Models.UserProfile;
 using SFA.DAS.EmployerAccounts.UnitTests.Fakes;
@@ -37,6 +38,8 @@ namespace SFA.DAS.EmployerAccounts.UnitTests.Commands.CreateInvitationTests
         private const string ExpectedHashedId = "aaa415ss1";
         private const string ExpectedCallerEmail = "test.user@test.local";
         private const string ExpectedExistingUserEmail = "registered@test.local";
+        private const string NameOfPersonBeingInvited = "Invited User";
+
 
         private static readonly string ExpectedExternalUserId = Guid.NewGuid().ToString();
 
@@ -73,7 +76,7 @@ namespace SFA.DAS.EmployerAccounts.UnitTests.Commands.CreateInvitationTests
             {
                 HashedAccountId = ExpectedHashedId,
                 EmailOfPersonBeingInvited = ExpectedCallerEmail,
-                NameOfPersonBeingInvited = "Test User",
+                NameOfPersonBeingInvited = NameOfPersonBeingInvited,
                 RoleIdOfPersonBeingInvited = Role.Owner,
                 ExternalUserId = ExpectedExternalUserId
             };
@@ -84,6 +87,15 @@ namespace SFA.DAS.EmployerAccounts.UnitTests.Commands.CreateInvitationTests
         public void Teardown()
         {
             DateTimeProvider.ResetToDefault();
+        }
+
+        [Test]
+        public async Task Then_InvitedUserEventPublishedWithCorrectPersonInvited()
+        {
+            //Act
+            await _handler.Handle(_command);
+
+            _endpoint.Verify(e =>e.Publish(It.Is<InvitedUserEvent>(i => i.PersonInvited == NameOfPersonBeingInvited)));
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerAccounts/Commands/CreateInvitation/CreateInvitationCommandHandler.cs
+++ b/src/SFA.DAS.EmployerAccounts/Commands/CreateInvitation/CreateInvitationCommandHandler.cs
@@ -131,7 +131,7 @@ namespace SFA.DAS.EmployerAccounts.Commands.CreateInvitation
 
             var callerExternalUserId = Guid.Parse(caller.UserRef);
 
-            await PublishUserInvitedEvent(caller.AccountId, caller.FullName(), message.NameOfPersonBeingInvited, callerExternalUserId);
+            await PublishUserInvitedEvent(caller.AccountId, message.NameOfPersonBeingInvited, caller.FullName(), callerExternalUserId);
         }
 
         private Task PublishUserInvitedEvent(long accountId, string personInvited, string invitedByUserName, Guid invitedByUserRef)


### PR DESCRIPTION
The user names were being crossed over, when publishing the user invited event.