### PR TITLE
Get Account Tests

### DIFF
--- a/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Api/Orchestrators/AccountsOrchestrator.cs
@@ -94,6 +94,12 @@ namespace SFA.DAS.EAS.Account.Api.Orchestrators
         public async Task<OrchestratorResponse<AccountDetailViewModel>> GetAccount(long accountId)
         {
             var hashedAccountId = _hashingService.HashValue(accountId);
+
+            if (string.IsNullOrWhiteSpace(hashedAccountId))
+            {
+                return new OrchestratorResponse<AccountDetailViewModel> { Data = null };
+            }
+
             var response = await GetAccount(hashedAccountId);
             return response;
         }

--- a/src/SFA.DAS.EAS.Web.IntegrationTests/EmployerAccountControllerTests/WhenGetAccountWithKnownIds.cs
+++ b/src/SFA.DAS.EAS.Web.IntegrationTests/EmployerAccountControllerTests/WhenGetAccountWithKnownIds.cs
@@ -1,0 +1,73 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SFA.DAS.EAS.Account.Api.Types;
+using SFA.DAS.EAS.Account.API.IntegrationTests.TestUtils.ApiTester;
+using SFA.DAS.EAS.Account.API.IntegrationTests.TestUtils.DataHelper;
+using SFA.DAS.EAS.Account.Api.Controllers;
+
+namespace SFA.DAS.EAS.Account.API.IntegrationTests.EmployerAccountControllerTests
+{
+    [TestFixture]
+    public class WhenGetAccountWithKnownIds
+    {
+        private ApiIntegrationTester _tester;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tester = new ApiIntegrationTester();
+
+            // Arrange
+            const string accountName = "ACME Fireworks";
+            const string legalEntityName = "RoadRunner Pest Control";
+
+            var builder = _tester.DbBuilder;
+            builder
+                .BeginTransaction()
+                .EnsureUserExists(builder.BuildUserInput())
+                .EnsureAccountExists(builder.BuildEmployerAccountInput(accountName))
+                .WithLegalEntity(builder.BuildEntityWithAgreementInput(legalEntityName))
+                .CommitTransaction();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _tester.Dispose();
+        }
+
+        [Test]
+        public async Task ThenTheStatusShouldBeFound_ByHashedAccountId()
+        {
+            var hashedAccountId = _tester.DbBuilder.Context.ActiveEmployerAccount.HashedAccountId;
+
+            var callRequirements = new CallRequirements($"api/accounts/{hashedAccountId}")
+                .ExpectControllerType(typeof(EmployerAccountsController))
+                .AllowStatusCodes(HttpStatusCode.OK);
+            
+            // Act
+            var account = await _tester.InvokeGetAsync<AccountDetailViewModel>(callRequirements);
+
+            // Assert
+            Assert.IsNotNull(account.Data);
+        }
+
+
+        [Test]
+        public async Task ThenTheStatusShouldBeFound_ByAccountId()
+        {
+            var accountId = _tester.DbBuilder.Context.ActiveEmployerAccount.AccountId;
+
+            var callRequirements = new CallRequirements($"api/accounts/internal/{accountId}")
+                .ExpectControllerType(typeof(EmployerAccountsController))
+                .AllowStatusCodes(HttpStatusCode.OK);
+
+            // Act
+            var account = await _tester.InvokeGetAsync<AccountDetailViewModel>(callRequirements);
+
+            // Assert
+            Assert.IsNotNull(account.Data);
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Web.IntegrationTests/EmployerAccountControllerTests/WhenGetAccountWithUnknownIds.cs
+++ b/src/SFA.DAS.EAS.Web.IntegrationTests/EmployerAccountControllerTests/WhenGetAccountWithUnknownIds.cs
@@ -1,0 +1,59 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SFA.DAS.EAS.Account.Api.Types;
+using SFA.DAS.EAS.Account.API.IntegrationTests.TestUtils.ApiTester;
+using SFA.DAS.EAS.Account.Api.Controllers;
+
+namespace SFA.DAS.EAS.Account.API.IntegrationTests.EmployerAccountControllerTests
+{
+    [TestFixture]
+    public class WhenGetAccountWithUnknownIds
+    {
+        private ApiIntegrationTester _tester;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tester = new ApiIntegrationTester();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _tester.Dispose();
+        }
+
+        [Test]
+        public async Task ThenTheStatusShouldBeNotFound_ById()
+        {
+            // Arrange
+            var callRequirements = new CallRequirements($"api/accounts/internal/-1")
+                .ExpectControllerType(typeof(EmployerAccountsController))
+                .AllowStatusCodes(HttpStatusCode.NotFound);
+
+            // Act
+            await _tester.InvokeGetAsync<AccountDetailViewModel>(callRequirements);
+
+            // Assert
+            Assert.Pass("Verified we got http status NotFound");
+        }
+
+
+        [Test]
+        public async Task ThenTheStatusShouldBeNotFound_ByHashedId()
+        {
+            // Arrange
+            var callRequirements = new CallRequirements($"api/accounts/MADE*UP*ID")
+                .ExpectControllerType(typeof(EmployerAccountsController))
+                .AllowStatusCodes(HttpStatusCode.NotFound);
+
+            // Act
+            await _tester.InvokeGetAsync<AccountDetailViewModel>(callRequirements);
+
+            // Assert
+            Assert.Pass("Verified we got http status NotFound");
+        }
+
+    }
+}

--- a/src/SFA.DAS.EAS.Web.IntegrationTests/SFA.DAS.EAS.Account.API.IntegrationTests.csproj
+++ b/src/SFA.DAS.EAS.Web.IntegrationTests/SFA.DAS.EAS.Account.API.IntegrationTests.csproj
@@ -201,7 +201,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EmployerAccountControllerTests\WhenGetAccountWithKnownIds.cs" />
     <Compile Include="EmployerAccountControllerTests\WhenGetLegalEntitiesWithNoKey.cs" />
+    <Compile Include="EmployerAccountControllerTests\WhenGetAccountWithUnknownIds.cs" />
     <Compile Include="HealthCheckControllerTests\WhenHealthCheck.cs" />
     <Compile Include="StatisitcsControllerTests\WhenIGetTheStatistics.cs" />
     <Compile Include="TestUtils\ApiTester\ApiIntegrationTester.cs" />


### PR DESCRIPTION
Orchestrator was modified to return a 404 when calling an API using an integer account id that does not resolve to a hash (-1). It was causing an internal server error code to be returned.