### PR TITLE
AML-3066 Clear local storage when we navigate to the setup account view

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_SetupAccount.cshtml
+++ b/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_SetupAccount.cshtml
@@ -13,3 +13,6 @@
         <p>If someone in your organisation has already created an account, you'll need to ask them to invite you to the account.</p>
     </div>
 </div>
+<script>
+    localStorage.clear();
+</script> 


### PR DESCRIPTION
Welcome wizard works by using javascript localStorage - this is never cleared down. I have set this to clear any time the users tries to setup a new account.