### PR TITLE
CON-80 Left Join Payment Meta Data when looking at course details

### DIFF
--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderAndDateRange.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderAndDateRange.sql
@@ -20,7 +20,7 @@ AS
 		SUM(CASE WHEN p.FundingSource = 2 THEN p.Amount END) * -1 AS SfaCoInvestmentAmount,
 		SUM(CASE WHEN p.FundingSource = 3 THEN p.Amount END) * -1 AS EmployerCoInvestmentAmount
 	FROM [employer_financial].[Payment] p
-	INNER JOIN [employer_financial].[PaymentMetaData] pm ON pm.Id = p.PaymentMetaDataId
+	LEFT JOIN [employer_financial].[PaymentMetaData] pm ON pm.Id = p.PaymentMetaDataId
 	INNER JOIN [employer_financial].[TransactionLine] t ON t.AccountId = p.AccountId AND t.PeriodEnd = p.PeriodEnd AND t.Ukprn = p.Ukprn
 	WHERE p.AccountId = @accountId
 	AND p.Ukprn = @ukprn

--- a/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderCourseAndDateRange.sql
+++ b/src/SFA.DAS.EAS.Employer_Financial.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderCourseAndDateRange.sql
@@ -26,7 +26,7 @@ FROM (
 		SUM(CASE WHEN p.FundingSource = 2 THEN -p.Amount ELSE 0 END) as SfaCoInvestmentAmount,
 		SUM(CASE WHEN p.FundingSource = 3 THEN -p.Amount ELSE 0 END) as EmployerCoInvestmentAmount
 	FROM [employer_financial].[Payment] p
-		JOIN [employer_financial].[PaymentMetaData] meta 
+		LEFT JOIN [employer_financial].[PaymentMetaData] meta 
 			ON	p.PaymentMetaDataId = meta.Id
 	WHERE 
 		p.AccountId = @AccountId


### PR DESCRIPTION
We have some cases where we have missing payment meta data. Using a left join to payments we make sure we receive the payment record with NULL values for the payment meta data.