### PR TITLE
Con 83 download transaction file not containing enough accuracy

### DIFF
--- a/src/SFA.DAS.EmployerFinance.UnitTests/Formatters/Transactions/CsvTransactionFormatterTests.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Formatters/Transactions/CsvTransactionFormatterTests.cs
@@ -77,18 +77,18 @@ namespace SFA.DAS.EmployerFinance.UnitTests.Formatters.Transactions
                 Assert.AreEqual($"{TransactionTypePrefix}{i}", dataRow[1]);
                 Assert.AreEqual($"{EmpRefPrefix}{i}", dataRow[2]);
                 Assert.AreEqual($"{PeriodEndPrefix}{i}", dataRow[3]);
-                Assert.AreEqual((i * 1000).ToString("0.00", CultureInfo.CurrentCulture), dataRow[4]); // LevyDeclared
-                Assert.AreEqual((i * 10).ToString("0.000", CultureInfo.CurrentCulture), dataRow[5]);
-                Assert.AreEqual((i * 100).ToString("0.00", CultureInfo.CurrentCulture), dataRow[6]);
+                Assert.AreEqual((i * 1000).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[4]); // LevyDeclared
+                Assert.AreEqual((i * 10).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[5]);
+                Assert.AreEqual((i * 100).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[6]);
                 Assert.AreEqual($"{TrainingProviderPrefix}{i}", dataRow[7]);
                 Assert.AreEqual($"{UlnPrefix}{i}", dataRow[8]);
                 Assert.AreEqual($"{ApprenticePrefix}{i}", dataRow[9]);
                 Assert.AreEqual($"{ApprenticeTrainingCoursePrefix}{i}", dataRow[10]);
                 Assert.AreEqual($"{ApprenticeTrainingCourseLevel}{i}", dataRow[11]);
-                Assert.AreEqual((i * 10).ToString("0.00", CultureInfo.CurrentCulture), dataRow[12]);
-                Assert.AreEqual((i).ToString("0.00", CultureInfo.CurrentCulture), dataRow[13]);
-                Assert.AreEqual((i * 10000).ToString("0.00", CultureInfo.CurrentCulture), dataRow[14]);
-                Assert.AreEqual(((i* 1000) + (i * 100)).ToString("0.00", CultureInfo.CurrentCulture), dataRow[15]);
+                Assert.AreEqual((i * 10).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[12]);
+                Assert.AreEqual((i).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[13]);
+                Assert.AreEqual((i * 10000).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[14]);
+                Assert.AreEqual(((i* 1000) + (i * 100)).ToString("0.00000", CultureInfo.CurrentCulture), dataRow[15]);
                 i++;
             }
         }

--- a/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
+++ b/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
@@ -19,15 +19,15 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal LevyDeclared { get; set; }
 
-        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal EnglishFraction { get; set; }
 
-        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.000", NumberFormatInfo.InvariantInfo);
+        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal TenPercentTopUp { get; set; }
 
-        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public string TrainingProvider { get; set; }
 
@@ -43,18 +43,18 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal PaidFromLevy { get; set; }
 
-        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal EmployerContribution { get; set; }
 
-        public string EmployerContributionFormatted => EmployerContribution.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string EmployerContributionFormatted => EmployerContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal GovermentContribution { get; set; }
 
-        public string GovermentContributionFormatted => GovermentContribution.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string GovermentContributionFormatted => GovermentContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal Total { get; set; }
 
-        public string TotalFormatted => Total.ToString("0.00", NumberFormatInfo.InvariantInfo);
+        public string TotalFormatted => Total.ToString("0.00000", NumberFormatInfo.InvariantInfo);
     }
 }

--- a/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
+++ b/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
@@ -19,15 +19,15 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal LevyDeclared { get; set; }
 
-        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public decimal EnglishFraction { get; set; }
 
-        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public decimal TenPercentTopUp { get; set; }
 
-        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public string TrainingProvider { get; set; }
 
@@ -43,18 +43,18 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal PaidFromLevy { get; set; }
 
-        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public decimal EmployerContribution { get; set; }
 
-        public string EmployerContributionFormatted => EmployerContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string EmployerContributionFormatted => EmployerContribution.ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public decimal GovermentContribution { get; set; }
 
-        public string GovermentContributionFormatted => GovermentContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string GovermentContributionFormatted => GovermentContribution.ToString("0.000000", NumberFormatInfo.InvariantInfo);
 
         public decimal Total { get; set; }
 
-        public string TotalFormatted => Total.ToString("0.00000", NumberFormatInfo.InvariantInfo);
+        public string TotalFormatted => Total.ToString("0.000000", NumberFormatInfo.InvariantInfo);
     }
 }

--- a/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
+++ b/src/SFA.DAS.EmployerFinance/Models/Transaction/TransactionDownloadLine.cs
@@ -19,15 +19,15 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal LevyDeclared { get; set; }
 
-        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string LevyDeclaredFormatted => LevyDeclared.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal EnglishFraction { get; set; }
 
-        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string EnglishFractionFormatted => (100 * EnglishFraction).ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal TenPercentTopUp { get; set; }
 
-        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string TenPercentTopUpFormatted => TenPercentTopUp.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public string TrainingProvider { get; set; }
 
@@ -43,18 +43,18 @@ namespace SFA.DAS.EmployerFinance.Models.Transaction
 
         public decimal PaidFromLevy { get; set; }
 
-        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string PaidFromLevyFormatted => PaidFromLevy.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal EmployerContribution { get; set; }
 
-        public string EmployerContributionFormatted => EmployerContribution.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string EmployerContributionFormatted => EmployerContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal GovermentContribution { get; set; }
 
-        public string GovermentContributionFormatted => GovermentContribution.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string GovermentContributionFormatted => GovermentContribution.ToString("0.00000", NumberFormatInfo.InvariantInfo);
 
         public decimal Total { get; set; }
 
-        public string TotalFormatted => Total.ToString("0.000000", NumberFormatInfo.InvariantInfo);
+        public string TotalFormatted => Total.ToString("0.00000", NumberFormatInfo.InvariantInfo);
     }
 }


### PR DESCRIPTION
Fix for download file not containing enough accuracy. Changed all string formats to 5 decimal places