### PR TITLE
Document id is accountid and partitionkey

### DIFF
--- a/src/SFA.DAS.EAS.Portal.Client.TestHarness/Program.cs
+++ b/src/SFA.DAS.EAS.Portal.Client.TestHarness/Program.cs
@@ -29,7 +29,7 @@ namespace SFA.DAS.EAS.Portal.Client.TestHarness
 
                 foreach (var accountDto in accountDtos)
                 {
-                    Console.WriteLine($"Account #{accountDto.AccountId} has {accountDto.AccountLegalEntities.Count()} ALEs");
+                    Console.WriteLine($"Account #{accountDto.Id} has {accountDto.AccountLegalEntities.Count()} ALEs");
                 }
 
                 await host.WaitForShutdownAsync();

--- a/src/SFA.DAS.EAS.Portal.Client/Application/Queries/GetAccountQuery.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Application/Queries/GetAccountQuery.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using SFA.DAS.CosmosDb;
 using SFA.DAS.EAS.Portal.Client.Data;
 using SFA.DAS.EAS.Portal.Client.Models.Concrete;
@@ -17,9 +19,14 @@ namespace SFA.DAS.EAS.Portal.Client.Application.Queries
 
         public async Task<AccountDto> Get(long accountId, CancellationToken cancellationToken = default)
         {
-            return await _accountsReadOnlyRepository.CreateQuery()
-                .FirstOrDefaultAsync( a => a.Deleted == null && a.AccountId == accountId, cancellationToken)
-                .ConfigureAwait(false);
+            // it seems using get by id when using partitioning, need to supply a partition key
+            // need to bake it into repo
+            var options = new RequestOptions {PartitionKey = new PartitionKey(accountId)};
+            var account = await _accountsReadOnlyRepository.GetById(accountId, options, cancellationToken: cancellationToken);
+            return account?.Deleted != null ? account : null;
+//            return await _accountsReadOnlyRepository.CreateQuery()
+//                .FirstOrDefaultAsync( a => a.Deleted == null && a.AccountId == accountId, cancellationToken)
+//                .ConfigureAwait(false);
         }
     }
 }

--- a/src/SFA.DAS.EAS.Portal.Client/Application/Queries/GetAccountQuery.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Application/Queries/GetAccountQuery.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.EAS.Portal.Client.Application.Queries
             _accountsReadOnlyRepository = accountsReadOnlyRepository;
         }
 
-        public async Task<AccountDto> Get(long accountId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AccountDto> Get(long accountId, CancellationToken cancellationToken = default)
         {
             return await _accountsReadOnlyRepository.CreateQuery()
                 .FirstOrDefaultAsync( a => a.Deleted == null && a.AccountId == accountId, cancellationToken)

--- a/src/SFA.DAS.EAS.Portal.Client/Data/AccountsReadOnlyRepository.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Data/AccountsReadOnlyRepository.cs
@@ -4,7 +4,7 @@ using SFA.DAS.EAS.Portal.Client.Models.Concrete;
 
 namespace SFA.DAS.EAS.Portal.Client.Data
 {
-    internal class AccountsReadOnlyRepository : ReadOnlyDocumentRepository<AccountDto>, IAccountsReadOnlyRepository
+    internal class AccountsReadOnlyRepository : EnhancedReadOnlyDocumentRepository<AccountDto, long>, IAccountsReadOnlyRepository
     {
         public AccountsReadOnlyRepository(IDocumentClient documentClient)
             : base(documentClient, DocumentSettings.DatabaseName, DocumentSettings.AccountsCollectionName)

--- a/src/SFA.DAS.EAS.Portal.Client/Data/EnhancedReadOnlyDocumentRepository.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Data/EnhancedReadOnlyDocumentRepository.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using SFA.DAS.CosmosDb;
+
+namespace SFA.DAS.EAS.Portal.Client.Data
+{
+    //todo: update ReadOnlyDocumentRepository directly in shared (hence current rubbish name)
+    public class EnhancedReadOnlyDocumentRepository<TDocument, TId> 
+        : ReadOnlyDocumentRepository<TDocument>, IEnhancedReadOnlyDocumentRepository<TDocument, TId> where TDocument : class
+    {
+        public EnhancedReadOnlyDocumentRepository(IDocumentClient documentClient, string databaseName, string collectionName)
+            : base(documentClient, databaseName, collectionName)
+        {
+        }
+        
+        public virtual async Task<TDocument> GetById(TId id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var response = await DocumentClient.ReadDocumentAsync<TDocument>(UriFactory.CreateDocumentUri(DatabaseName, CollectionName, id.ToString()), requestOptions, cancellationToken).ConfigureAwait(false);
+
+                return response.Document;
+            }
+            catch (DocumentClientException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.NotFound)
+                    return default;
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Portal.Client/Data/IAccountsReadOnlyRepository.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Data/IAccountsReadOnlyRepository.cs
@@ -1,9 +1,8 @@
-using SFA.DAS.CosmosDb;
 using SFA.DAS.EAS.Portal.Client.Models.Concrete;
 
 namespace SFA.DAS.EAS.Portal.Client.Data
 {
-    internal interface IAccountsReadOnlyRepository : IReadOnlyDocumentRepository<AccountDto>
+    internal interface IAccountsReadOnlyRepository : IEnhancedReadOnlyDocumentRepository<AccountDto, long>
     {
     }
 }

--- a/src/SFA.DAS.EAS.Portal.Client/Data/IEnhancedReadOnlyDocumentRepository.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Data/IEnhancedReadOnlyDocumentRepository.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Client;
+using SFA.DAS.CosmosDb;
+
+namespace SFA.DAS.EAS.Portal.Client.Data
+{
+    public interface IEnhancedReadOnlyDocumentRepository<TDocument, TId> : IReadOnlyDocumentRepository<TDocument> where TDocument : class
+    {
+        Task<TDocument> GetById(TId id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/SFA.DAS.EAS.Portal.Client/IPortalClient.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/IPortalClient.cs
@@ -6,6 +6,6 @@ namespace SFA.DAS.EAS.Portal.Client
 {
     public interface IPortalClient
     {
-        Task<AccountDto> GetAccount(long accountId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AccountDto> GetAccount(long accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/SFA.DAS.EAS.Portal.Client/Models/Concrete/AccountDto.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Models/Concrete/AccountDto.cs
@@ -11,8 +11,9 @@ namespace SFA.DAS.EAS.Portal.Client.Models.Concrete
             AccountLegalEntities = accountLegalEntities;
         }
 
-        [JsonProperty("accountId")]
-        public virtual long AccountId { get; private set; }
+        [JsonProperty("id")]
+//        public virtual string AccountId { get; private set; }
+        public virtual string Id { get; private set; }
 
         //todo: return List in dto's, not enumerable (so consumer can add to them without copying - return most specific type)
         // https://stackoverflow.com/questions/15490633/why-cant-i-use-a-compatible-concrete-type-when-implementing-an-interface

--- a/src/SFA.DAS.EAS.Portal.Client/Models/IAccountDto.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/Models/IAccountDto.cs
@@ -7,7 +7,8 @@ namespace SFA.DAS.EAS.Portal.Client.Models
     public interface IAccountDto<out TAccountLegalEntityDto> 
         where TAccountLegalEntityDto : IAccountLegalEntityDto<IReservedFundingDto>
     {
-        long AccountId { get; }
+//        string AccountId { get; }
+        string Id { get; }
         IEnumerable<TAccountLegalEntityDto> AccountLegalEntities { get; }
         DateTime? Deleted { get; }
     }

--- a/src/SFA.DAS.EAS.Portal.Client/PortalClient.cs
+++ b/src/SFA.DAS.EAS.Portal.Client/PortalClient.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.EAS.Portal.Client
 //        {
 //        }
         
-        public Task<AccountDto> GetAccount(long accountId, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<AccountDto> GetAccount(long accountId, CancellationToken cancellationToken = default)
         {
             return _getAccountQuery.Get(accountId, cancellationToken);
         }

--- a/src/SFA.DAS.EAS.Portal.Worker/StartupJobs/CreateReadStoreDatabaseJob.cs
+++ b/src/SFA.DAS.EAS.Portal.Worker/StartupJobs/CreateReadStoreDatabaseJob.cs
@@ -90,7 +90,7 @@ namespace SFA.DAS.EAS.Portal.Worker.StartupJobs
                 {
                     Paths = new Collection<string>
                     {
-                        "/accountId"
+                        "/id"
                     }
                 }
             };

--- a/src/SFA.DAS.EAS.Portal/Application/Commands/AddReservationCommand.cs
+++ b/src/SFA.DAS.EAS.Portal/Application/Commands/AddReservationCommand.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.EAS.Portal.Application.Commands
             _logger = logger;
         }
 
-        public async Task Execute(ReservationCreatedEvent reservedFunding, string messageId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task Execute(ReservationCreatedEvent reservedFunding, string messageId, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Executing AddReservationCommand");
 

--- a/src/SFA.DAS.EAS.Portal/Application/Commands/AddReservationCommand.cs
+++ b/src/SFA.DAS.EAS.Portal/Application/Commands/AddReservationCommand.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.CosmosDb;
 using SFA.DAS.EAS.Portal.Database;
@@ -24,9 +26,12 @@ namespace SFA.DAS.EAS.Portal.Application.Commands
             _logger.LogInformation("Executing AddReservationCommand");
 
             // can we have accountid as key, rather than guid??
-            var account = await _accountsRepository
-                .CreateQuery()
-                .SingleOrDefaultAsync(a => a.AccountId == reservedFunding.AccountId, cancellationToken);
+//            var account = await _accountsRepository
+//                .CreateQuery()
+//                .SingleOrDefaultAsync(a => a.AccountId == reservedFunding.AccountId, cancellationToken);
+
+            var options = new RequestOptions {PartitionKey = new PartitionKey(reservedFunding.AccountId)};
+            var account = await _accountsRepository.GetById(reservedFunding.AccountId, options, cancellationToken);
 
             if (account == null)
             {

--- a/src/SFA.DAS.EAS.Portal/Database/AccountRepository.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/AccountRepository.cs
@@ -1,11 +1,10 @@
 using Microsoft.Azure.Documents;
-using SFA.DAS.CosmosDb;
 using SFA.DAS.EAS.Portal.Client.Data;
 using SFA.DAS.EAS.Portal.Database.Models;
 
 namespace SFA.DAS.EAS.Portal.Database
 {
-    public class AccountsRepository : DocumentRepository<Account>, IAccountsRepository
+    public class AccountsRepository : EnhancedDocumentRepository<Account, long>, IAccountsRepository
     {
         public AccountsRepository(IDocumentClient documentClient)
             : base(documentClient, DocumentSettings.DatabaseName, DocumentSettings.AccountsCollectionName)

--- a/src/SFA.DAS.EAS.Portal/Database/EnhancedDocumentRepository.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/EnhancedDocumentRepository.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using SFA.DAS.EAS.Portal.Client.Data;
+using SFA.DAS.EAS.Portal.Database.Models;
+
+namespace SFA.DAS.EAS.Portal.Database
+{
+    public class EnhancedDocumentRepository<TDocument, TId> : EnhancedReadOnlyDocumentRepository<TDocument, TId>, IEnhancedDocumentRepository<TDocument, TId> where TDocument : class, IDocument
+    {
+        public EnhancedDocumentRepository(IDocumentClient documentClient, string databaseName, string collectionName)
+            : base(documentClient, databaseName, collectionName)
+        {
+        }
+
+        public virtual Task Add(TDocument document, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            if (document == null)
+                throw new ArgumentNullException(nameof(document));
+            
+//            if (EqualityComparer<TId>.Default.Equals(document.Id, default))
+//                throw new Exception("Id must not be default");
+            if (document.Id == null)
+                throw new Exception("Document Id must be supplied");
+            
+            return DocumentClient.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri(DatabaseName, CollectionName), document, requestOptions, true, cancellationToken);
+        }
+        
+        public virtual Task Remove(TId id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return DocumentClient.DeleteDocumentAsync(UriFactory.CreateDocumentUri(DatabaseName, CollectionName, id.ToString()), requestOptions, cancellationToken);
+        }
+
+        public virtual Task Update(TDocument document, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            if (document == null)
+                throw new ArgumentNullException(nameof(document));
+            
+//            if (EqualityComparer<TId>.Default.Equals(document.Id, default))
+//                throw new Exception("Id must not be default");
+            if (document.Id == null)
+                throw new Exception("Document Id must be supplied");
+
+            requestOptions = AddOptimisticLockingIfETagSetAndNoAccessConditionDefined(document, requestOptions);
+
+            return DocumentClient.ReplaceDocumentAsync(UriFactory.CreateDocumentUri(DatabaseName, CollectionName, document.Id.ToString()), document, requestOptions, cancellationToken);
+        }
+
+        private RequestOptions AddOptimisticLockingIfETagSetAndNoAccessConditionDefined(IDocument document, RequestOptions requestOptions)
+        {
+            var options = requestOptions ?? new RequestOptions();
+            if (options.AccessCondition == null)
+            {
+                if (!string.IsNullOrWhiteSpace(document.ETag))
+                {
+                    options.AccessCondition = new AccessCondition {
+                        Condition = document.ETag,
+                        Type = AccessConditionType.IfMatch
+                    };
+                }
+            }
+            return options;
+        }
+    }
+}

--- a/src/SFA.DAS.EAS.Portal/Database/IAccountsRepository.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/IAccountsRepository.cs
@@ -3,7 +3,7 @@ using SFA.DAS.EAS.Portal.Database.Models;
 
 namespace SFA.DAS.EAS.Portal.Database
 {
-    public interface IAccountsRepository : IDocumentRepository<Account>
+    public interface IAccountsRepository : IEnhancedDocumentRepository<Account, long>
     {
     }
 }

--- a/src/SFA.DAS.EAS.Portal/Database/IDocument.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/IDocument.cs
@@ -1,0 +1,8 @@
+//namespace SFA.DAS.EAS.Portal.Database
+//{
+//    public interface IDocument<TId>
+//    {
+//        TId Id { get; }
+//        string ETag { get; }
+//    }
+//}

--- a/src/SFA.DAS.EAS.Portal/Database/IEnhancedDocumentRepository.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/IEnhancedDocumentRepository.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Client;
+
+namespace SFA.DAS.EAS.Portal.Database
+{
+    public interface IEnhancedDocumentRepository<TDocument, TId> //: IDocumentRepository<TDocument> where TDocument : class //, IDocument<TId>
+    {
+        Task Add(TDocument document, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+        IQueryable<TDocument> CreateQuery(FeedOptions feedOptions = null);
+        Task<TDocument> GetById(TId id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+        Task Remove(TId id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+        Task Update(TDocument document, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/SFA.DAS.EAS.Portal/Database/Models/Account.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/Models/Account.cs
@@ -9,8 +9,8 @@ namespace SFA.DAS.EAS.Portal.Database.Models
     public class Account : Document, IAccountDto<AccountLegalEntity>
     {
         //todo: doc id / accountid
-        [JsonProperty("accountId")]
-        public long AccountId { get; private set; }
+//        [JsonProperty("id")]
+//        public string AccountId { get; private set; }
 
         [JsonProperty("accountLegalEntities")]
         public IEnumerable<AccountLegalEntity> AccountLegalEntities => _accountLegalEntities;
@@ -36,8 +36,9 @@ namespace SFA.DAS.EAS.Portal.Database.Models
         private Account(long accountId, DateTime created, string messageId)
             : base(1)
         {
-            Id = Guid.NewGuid();
-            AccountId = accountId;
+//            Id = Guid.NewGuid();
+//            AccountId = accountId.ToString();
+            Id = accountId.ToString();
             // the created date originates from event publishers, so we make sure we store it as UTC
             Created = DateTime.SpecifyKind(created, DateTimeKind.Utc);
             

--- a/src/SFA.DAS.EAS.Portal/Database/Models/Document.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/Models/Document.cs
@@ -1,13 +1,11 @@
-using System;
 using Newtonsoft.Json;
-using SFA.DAS.CosmosDb;
 
 namespace SFA.DAS.EAS.Portal.Database.Models
 {
     public abstract class Document : IDocument
     {
         [JsonProperty("id")]
-        public Guid Id { get; protected set; }
+        public string Id { get; protected set; }
 
         [JsonIgnore]
         public string ETag { get; protected set; }

--- a/src/SFA.DAS.EAS.Portal/Database/Models/IDocument.cs
+++ b/src/SFA.DAS.EAS.Portal/Database/Models/IDocument.cs
@@ -1,0 +1,8 @@
+namespace SFA.DAS.EAS.Portal.Database.Models
+{
+    public interface IDocument
+    {
+        string Id { get; }
+        string ETag { get; }
+    }
+}


### PR DESCRIPTION
This is work-in-progress to change the portal's cosmosdb document over to use the account id as the document's id and also using the id as the partition key.

Looks like there is not enough time to finish this and thoroughly check the implications of the change, so parking in this PR.