### PR TITLE
Aml 3694 fix multi account creation when going back and forth

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Controllers/EmployerAccountControllerTests/GetApprenticeshipFunding/GivenReturnUrlIsSpecified/WhenISkipRegistration.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Controllers/EmployerAccountControllerTests/GetApprenticeshipFunding/GivenReturnUrlIsSpecified/WhenISkipRegistration.cs
@@ -52,7 +52,7 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Controllers.EmployerAccountCont
             };
 
             _orchestrator.Setup(x =>
-                    x.CreateUserAccount(It.IsAny<CreateUserAccountViewModel>(), It.IsAny<HttpContextBase>()))
+                    x.CreateMinimalUserAccountForSkipJourney(It.IsAny<CreateUserAccountViewModel>(), It.IsAny<HttpContextBase>()))
                 .ReturnsAsync(_response);
 
             _returnUrlCookieStorage.Setup(x => x.Get("SFA.DAS.EmployerAccounts.Web.Controllers.ReturnUrlCookie"))

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Controllers/EmployerAccountControllerTests/GetApprenticeshipFunding/WhenISkipRegistration.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Controllers/EmployerAccountControllerTests/GetApprenticeshipFunding/WhenISkipRegistration.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Controllers.EmployerAccountCont
                 Status = HttpStatusCode.OK
             };
 
-            _orchestrator.Setup(x => x.CreateUserAccount(It.IsAny<CreateUserAccountViewModel>(), It.IsAny<HttpContextBase>()))
+            _orchestrator.Setup(x => x.CreateMinimalUserAccountForSkipJourney(It.IsAny<CreateUserAccountViewModel>(), It.IsAny<HttpContextBase>()))
                 .ReturnsAsync(_response);        
 
             _employerAccountController = new EmployerAccountController(

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web;
+using MediatR;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerAccounts.Commands.CreateUserAccount;
+using SFA.DAS.EmployerAccounts.Configuration;
+using SFA.DAS.EmployerAccounts.Interfaces;
+using SFA.DAS.EmployerAccounts.Models.Account;
+using SFA.DAS.EmployerAccounts.Models.AccountTeam;
+using SFA.DAS.EmployerAccounts.Models.UserProfile;
+using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
+using SFA.DAS.EmployerAccounts.Web.Orchestrators;
+using SFA.DAS.EmployerAccounts.Web.ViewModels;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOrchestratorTests.CreateMinimalUserAccountForSkipJourney.Given_User_Does_Already_Have_An_Account
+{
+    public class WhenCreatingTheUserAccount
+    {
+        private EmployerAccountOrchestrator _employerAccountOrchestrator;
+        private Mock<IMediator> _mediator;
+        private Mock<ILog> _logger;
+        private Mock<ICookieStorageService<EmployerAccountData>> _cookieService;
+        private EmployerAccountsConfiguration _configuration;
+        private string _existingAccountHashedId = "B3AE4BBE-7E75-4FF3-89B8-3C24FDFCFE10";
+
+        [SetUp]
+        public void Arrange()
+        {
+            _mediator = new Mock<IMediator>();
+            _logger = new Mock<ILog>();
+            _cookieService = new Mock<ICookieStorageService<EmployerAccountData>>();
+            _configuration = new EmployerAccountsConfiguration();
+
+            _employerAccountOrchestrator = new EmployerAccountOrchestrator(
+                _mediator.Object, 
+                _logger.Object,
+                _cookieService.Object, 
+                _configuration);
+
+
+            var existingUserDetails =
+                new User();
+
+            existingUserDetails
+                .Memberships
+                .Add(new Membership
+                    {
+                        Account = new Account { HashedId = _existingAccountHashedId }
+                    }
+                );
+
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserByRefQuery>()))
+                .ReturnsAsync(new GetUserByRefResponse()
+                {
+                    User  = existingUserDetails
+                });
+        }
+
+        [Test]
+        public async Task ThenNewAccountIsNotCreated()
+        {
+            await _employerAccountOrchestrator.CreateMinimalUserAccountForSkipJourney(
+                ArrangeModel(),
+                It.IsAny<HttpContextBase>());
+
+            _mediator.Verify(
+                x => x.SendAsync<CreateUserAccountCommandResponse>(
+                    It.IsAny<CreateUserAccountCommand>()),
+                Times.Never());
+        }
+
+        [Test]
+        public async Task ThenResponseContainsHashedIdOfExistingAccount()
+        {
+            var response =
+                await _employerAccountOrchestrator.CreateMinimalUserAccountForSkipJourney(new CreateUserAccountViewModel(),
+                    It.IsAny<HttpContextBase>());
+
+            Assert.AreEqual(_existingAccountHashedId, response.Data?.HashedId);
+        }
+
+        private static CreateUserAccountViewModel ArrangeModel()
+        {
+            return new CreateUserAccountViewModel
+            {
+                OrganisationName = "test",
+                UserId = Guid.NewGuid().ToString()
+            };
+        }
+    }
+
+    public class TestUser : User
+    {
+        public TestUser(ICollection<Membership> injectedMemberships)
+        {
+            Memberships = injectedMemberships;
+        }
+    }
+}
+

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
@@ -11,7 +11,7 @@ using SFA.DAS.EmployerAccounts.Interfaces;
 using SFA.DAS.EmployerAccounts.Models.Account;
 using SFA.DAS.EmployerAccounts.Models.AccountTeam;
 using SFA.DAS.EmployerAccounts.Models.UserProfile;
-using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
+using SFA.DAS.EmployerAccounts.Queries.GetUserAccounts;
 using SFA.DAS.EmployerAccounts.Web.Orchestrators;
 using SFA.DAS.EmployerAccounts.Web.ViewModels;
 using SFA.DAS.NLog.Logger;
@@ -42,21 +42,10 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOr
                 _configuration);
 
 
-            var existingUserDetails =
-                new User();
-
-            existingUserDetails
-                .Memberships
-                .Add(new Membership
-                    {
-                        Account = new Account { HashedId = _existingAccountHashedId }
-                    }
-                );
-
-            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserByRefQuery>()))
-                .ReturnsAsync(new GetUserByRefResponse()
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserAccountsQuery>()))
+                .ReturnsAsync(new GetUserAccountsQueryResponse()
                 {
-                    User  = existingUserDetails
+                    Accounts = new Accounts<Account> { AccountsCount = 1, AccountList = new List<Account>{ new Account { HashedId = _existingAccountHashedId } } }
                 });
         }
 

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Not_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Not_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
@@ -9,6 +9,7 @@ using SFA.DAS.EmployerAccounts.Configuration;
 using SFA.DAS.EmployerAccounts.Interfaces;
 using SFA.DAS.EmployerAccounts.Models.Account;
 using SFA.DAS.EmployerAccounts.Models.UserProfile;
+using SFA.DAS.EmployerAccounts.Queries.GetUserAccounts;
 using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
 using SFA.DAS.EmployerAccounts.Web.Orchestrators;
 using SFA.DAS.EmployerAccounts.Web.ViewModels;
@@ -38,10 +39,10 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOr
                 _cookieService.Object, 
                 _configuration);
 
-            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserByRefQuery>()))
-                .ReturnsAsync(new GetUserByRefResponse()
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserAccountsQuery>()))
+                .ReturnsAsync(new GetUserAccountsQueryResponse()
                 {
-                    User = new User()
+                    Accounts = new Accounts<Account>()
                 });
 
 

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Not_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/CreateMinimalUserAccountForSkipJourney/Given_User_Does_Not_Already_Have_An_Account/WhenCreatingTheUserAccount.cs
@@ -8,11 +8,13 @@ using SFA.DAS.EmployerAccounts.Commands.CreateUserAccount;
 using SFA.DAS.EmployerAccounts.Configuration;
 using SFA.DAS.EmployerAccounts.Interfaces;
 using SFA.DAS.EmployerAccounts.Models.Account;
+using SFA.DAS.EmployerAccounts.Models.UserProfile;
+using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
 using SFA.DAS.EmployerAccounts.Web.Orchestrators;
 using SFA.DAS.EmployerAccounts.Web.ViewModels;
 using SFA.DAS.NLog.Logger;
 
-namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOrchestratorTests
+namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOrchestratorTests.CreateMinimalUserAccountForSkipJourney.Given_User_Does_Not_Already_Have_An_Account
 {
     public class WhenCreatingTheUserAccount
     {
@@ -35,6 +37,13 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOr
                 _logger.Object,
                 _cookieService.Object, 
                 _configuration);
+
+            _mediator.Setup(x => x.SendAsync(It.IsAny<GetUserByRefQuery>()))
+                .ReturnsAsync(new GetUserByRefResponse()
+                {
+                    User = new User()
+                });
+
 
             _mediator.Setup(x => x.SendAsync(It.IsAny<CreateUserAccountCommand>()))
                 .ReturnsAsync(new CreateUserAccountCommandResponse()

--- a/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/WhenCreatingTheUserAccount.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web.UnitTests/Orchestrators/EmployerAccountOrchestratorTests/WhenCreatingTheUserAccount.cs
@@ -50,7 +50,7 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOr
             var model = ArrangeModel();
 
             //Act
-            await _employerAccountOrchestrator.CreateUserAccount(model, It.IsAny<HttpContextBase>());
+            await _employerAccountOrchestrator.CreateMinimalUserAccountForSkipJourney(model, It.IsAny<HttpContextBase>());
 
             //Assert
             _mediator.Verify(x => x.SendAsync(It.Is<CreateUserAccountCommand>(
@@ -72,7 +72,7 @@ namespace SFA.DAS.EmployerAccounts.Web.UnitTests.Orchestrators.EmployerAccountOr
 
             //Act
             var response =
-                await _employerAccountOrchestrator.CreateUserAccount(new CreateUserAccountViewModel(),
+                await _employerAccountOrchestrator.CreateMinimalUserAccountForSkipJourney(new CreateUserAccountViewModel(),
                     It.IsAny<HttpContextBase>());
 
             //Assert

--- a/src/SFA.DAS.EmployerAccounts.Web/Controllers/EmployerAccountController.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web/Controllers/EmployerAccountController.cs
@@ -196,7 +196,7 @@ namespace SFA.DAS.EmployerAccounts.Web.Controllers
                         OrganisationName = "MY ACCOUNT"
                     };
 
-                    var response = await _employerAccountOrchestrator.CreateUserAccount(request, HttpContext);
+                    var response = await _employerAccountOrchestrator.CreateMinimalUserAccountForSkipJourney(request, HttpContext);
                     var returnUrlCookie = _returnUrlCookieStorageService.Get(ReturnUrlCookieName);
                     _returnUrlCookieStorageService.Delete(ReturnUrlCookieName);
                     if (returnUrlCookie != null && !returnUrlCookie.Value.IsNullOrWhiteSpace())

--- a/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using MediatR;
 using SFA.DAS.Authorization;
 using SFA.DAS.EmployerAccounts.Commands.RenameEmployerAccount;
@@ -17,6 +18,7 @@ using SFA.DAS.EmployerAccounts.Commands.CreateAccount;
 using SFA.DAS.EmployerAccounts.Commands.CreateLegalEntity;
 using SFA.DAS.EmployerAccounts.Commands.CreateUserAccount;
 using SFA.DAS.EmployerAccounts.Models.EmployerAgreement;
+using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
 using SFA.DAS.EmployerAccounts.Web.Models;
 
 namespace SFA.DAS.EmployerAccounts.Web.Orchestrators
@@ -256,6 +258,19 @@ namespace SFA.DAS.EmployerAccounts.Web.Orchestrators
         {
             try
             {
+                var existingUserInformation =
+                    await Mediator.SendAsync(new GetUserByRefQuery {UserRef = viewModel.UserId});
+
+                if(existingUserInformation.User.Memberships.Any())
+                    return new OrchestratorResponse<EmployerAccountViewModel>
+                    {
+                        Data = new EmployerAccountViewModel
+                        {
+                            HashedId = existingUserInformation.User.Memberships.First().Account.HashedId
+                        },
+                        Status = HttpStatusCode.OK
+                    };
+
                 var result = await Mediator.SendAsync(new CreateUserAccountCommand
                 {
                     ExternalUserId = viewModel.UserId,

--- a/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
@@ -252,7 +252,7 @@ namespace SFA.DAS.EmployerAccounts.Web.Orchestrators
             }
         }
 
-        public virtual async Task<OrchestratorResponse<EmployerAccountViewModel>> CreateUserAccount(CreateUserAccountViewModel viewModel, HttpContextBase context)
+        public virtual async Task<OrchestratorResponse<EmployerAccountViewModel>> CreateMinimalUserAccountForSkipJourney(CreateUserAccountViewModel viewModel, HttpContextBase context)
         {
             try
             {

--- a/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
+++ b/src/SFA.DAS.EmployerAccounts.Web/Orchestrators/EmployerAccountOrchestrator.cs
@@ -18,6 +18,7 @@ using SFA.DAS.EmployerAccounts.Commands.CreateAccount;
 using SFA.DAS.EmployerAccounts.Commands.CreateLegalEntity;
 using SFA.DAS.EmployerAccounts.Commands.CreateUserAccount;
 using SFA.DAS.EmployerAccounts.Models.EmployerAgreement;
+using SFA.DAS.EmployerAccounts.Queries.GetUserAccounts;
 using SFA.DAS.EmployerAccounts.Queries.GetUserByRef;
 using SFA.DAS.EmployerAccounts.Web.Models;
 
@@ -258,15 +259,15 @@ namespace SFA.DAS.EmployerAccounts.Web.Orchestrators
         {
             try
             {
-                var existingUserInformation =
-                    await Mediator.SendAsync(new GetUserByRefQuery {UserRef = viewModel.UserId});
+                var existingUserAccounts =
+                    await Mediator.SendAsync(new GetUserAccountsQuery {UserRef = viewModel.UserId});
 
-                if(existingUserInformation.User.Memberships.Any())
+                if(existingUserAccounts?.Accounts?.AccountList?.Any() == true)
                     return new OrchestratorResponse<EmployerAccountViewModel>
                     {
                         Data = new EmployerAccountViewModel
                         {
-                            HashedId = existingUserInformation.User.Memberships.First().Account.HashedId
+                            HashedId = existingUserAccounts.Accounts.AccountList.First().HashedId
                         },
                         Status = HttpStatusCode.OK
                     };


### PR DESCRIPTION
Two approaches in this history; first attempt failed, because the return type of a query lied about what it actually was :0(

This is a bit crufty, but works with local testing.