### PR TITLE
Reverted portal workerAppServiceLocation parameter addition

### DIFF
--- a/azure/portal.template.json
+++ b/azure/portal.template.json
@@ -25,9 +25,6 @@
         },
         "workerAppServicePlanInstances": {
             "type": "int"
-        },
-        "workerAppServiceLocation": {
-            "type": "string"
         }
     },
     "variables": {
@@ -121,9 +118,6 @@
                     },
                     "appServicePlanResourceGroup": {
                         "value": "[resourceGroup().name]"
-                    },
-                    "appServiceLocation": {
-                        "value": "[parameters('workerAppServiceLocation')]"
                     },
                     "appServiceAppSettings": {
                         "value": [


### PR DESCRIPTION
Reverted portal workerAppServiceLocation parameter addition.

-Resource group is now in West Europe
--workerAppServiceLocation parameter is no longer needed as the worker app service's location can use the resource group's location.