### PR TITLE
Removing CloudConfigurationManager resolving of Configuration.

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Api/Startup.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Startup.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Azure;
-using Microsoft.Owin;
+﻿using Microsoft.Owin;
 using Microsoft.Owin.Security.ActiveDirectory;
 using Owin;
+using SFA.DAS.AutoConfiguration;
+using System.Web.Http;
 
 [assembly: OwinStartup(typeof(SFA.DAS.EmployerAccounts.Api.Startup))]
 
@@ -10,14 +11,16 @@ namespace SFA.DAS.EmployerAccounts.Api
     public class Startup
     {
         public void Configuration(IAppBuilder app)
-        {
+        {            
+            IEnvironmentService environmentService = GlobalConfiguration.Configuration.DependencyResolver.GetService(typeof(IEnvironmentService)) as IEnvironmentService;
+
             app.UseWindowsAzureActiveDirectoryBearerAuthentication(new WindowsAzureActiveDirectoryBearerAuthenticationOptions
             {
-                Tenant = CloudConfigurationManager.GetSetting("idaTenant"),
+                Tenant = environmentService.GetVariable("idaTenant"),
                 TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                 {
                     RoleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
-                    ValidAudience = CloudConfigurationManager.GetSetting("idaAudience")
+                    ValidAudience = environmentService.GetVariable("idaAudience")
                 }
             });
         }


### PR DESCRIPTION
Removing CloudConfigurationManager resolving of Configuration. 

This requires environment variables setup in the VSTS pipeline which DevOps are trying to move away from. As these were not set we kept getting 401 Unauthorised errors when accessing the new Accounts Api because it had no config to know where to validate its tokens against.

This will require an update to the Accounts Template Schema Json to make sure it's mapped across. ( I think )