### PR TITLE
Update App Insights, Remove Cloud Configuration

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Api/Global.asax.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Global.asax.cs
@@ -1,5 +1,7 @@
-﻿using System.Web;
+﻿using System.Configuration;
+using System.Web;
 using System.Web.Http;
+using Microsoft.ApplicationInsights.Extensibility;
 using NServiceBus;
 using StructureMap;
 using WebApi.StructureMap;
@@ -14,6 +16,7 @@ namespace SFA.DAS.EmployerAccounts.Api
         protected void Application_Start()
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
+            TelemetryConfiguration.Active.InstrumentationKey = ConfigurationManager.AppSettings["InstrumentationKey"];
 
             _serviceBusEndpointManager = 
                 new ServiceBusEndPointConfigureAndRun(

--- a/src/SFA.DAS.EmployerAccounts.Api/SFA.DAS.EmployerAccounts.Api.csproj
+++ b/src/SFA.DAS.EmployerAccounts.Api/SFA.DAS.EmployerAccounts.Api.csproj
@@ -46,9 +46,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="5.1.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.11.0" />
+    <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="1.0.8" />
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.1" />

--- a/src/SFA.DAS.EmployerAccounts.Api/Startup.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Startup.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Azure;
-using Microsoft.Owin;
+﻿using Microsoft.Owin;
 using Microsoft.Owin.Security.ActiveDirectory;
 using Owin;
+using System.Configuration;
 
 [assembly: OwinStartup(typeof(SFA.DAS.EmployerAccounts.Api.Startup))]
 
@@ -13,11 +13,11 @@ namespace SFA.DAS.EmployerAccounts.Api
         {
             app.UseWindowsAzureActiveDirectoryBearerAuthentication(new WindowsAzureActiveDirectoryBearerAuthenticationOptions
             {
-                Tenant = CloudConfigurationManager.GetSetting("idaTenant"),
+                Tenant = ConfigurationManager.AppSettings["idaTenant"],
                 TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                 {
                     RoleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
-                    ValidAudience = CloudConfigurationManager.GetSetting("idaAudience")
+                    ValidAudience = ConfigurationManager.AppSettings["idaAudience"]
                 }
             });
         }

--- a/src/SFA.DAS.EmployerAccounts.Api/Web.config
+++ b/src/SFA.DAS.EmployerAccounts.Api/Web.config
@@ -9,6 +9,7 @@
     <add key="EnvironmentName" value="LOCAL" />
     <add key="idaAudience" value="https://citizenazuresfabisgov.onmicrosoft.com/eas-api" />
     <add key="idaTenant" value="citizenazuresfabisgov.onmicrosoft.com" />
+    <add key="InstrumentationKey" value="" />
   </appSettings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">


### PR DESCRIPTION
Following Error occurred in Test 2. Recommended action was to update insights and remove cloud configuration as its an app service, not a cloud service.

<Data>Exception has been thrown by the target of an invocation.
  at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean noCheck, Boolean&amp; canBeCached, RuntimeMethodHandleInternal&amp; ctor, Boolean&amp; bNeedSecurityCheck)
  at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark&amp; stackMark)
  at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark&amp; stackMark)
  at System.Activator.CreateInstance(Type type, Boolean nonPublic)
  at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, StackCrawlMark&amp; stackMark)
  at System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)
  at System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture)
  at System.Web.HttpRuntime.CreateNonPublicInstance(Type type, Object[] args)
  at System.Web.HttpRuntime.CreateNonPublicInstanceByWebObjectActivator(Type type)
  at System.Web.HttpApplication.BuildIntegratedModuleCollection(List`1 moduleList)
  at System.Web.HttpApplication.GetModuleCollection(IntPtr appContext)
  at System.Web.HttpApplication.RegisterEventSubscriptionsWithIIS(IntPtr appContext, HttpContext context, MethodInfo[] handlers)
  at System.Web.HttpApplication.InitSpecial(HttpApplicationState state, MethodInfo[] handlers, IntPtr appContext, HttpContext context)
  at System.Web.HttpApplicationFactory.GetSpecialApplicationInstance(IntPtr appContext, HttpContext context)
  at System.Web.Hosting.PipelineRuntime.InitializeApplication(IntPtr appContext)
Could not load file or assembly 'Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The module was expected to contain an assembly manifest.
  at Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule..ctor()`