### PR TITLE
AD-1213 - Prevent the Zendesk widget from attaching files to new tickets

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_ZenDeskWidget.cshtml
+++ b/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_ZenDeskWidget.cshtml
@@ -1,4 +1,13 @@
 ﻿@if (ViewBag.HideZenDeskWidget == null || ViewBag.HideZenDeskWidget == false)
 {
+    <script type="text/javascript">
+        window.zESettings = {
+            webWidget: {
+                contactForm: {
+                    attachments: false
+                }
+            }
+        };
+    </script>
     <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=1b1ce288-39ea-4d40-a5e1-3a5e08aadd89"></script>
 }


### PR DESCRIPTION
Zendesk does not scan any files that are attached to tickets via the widget, and there is a concern that viruses / other malicious files may slip through.

It is not possible to disable widget attachments globally, it must be done on every page the widget is shown:
https://developer.zendesk.com/embeddables/docs/widget/settings#attachments

ASCS widget item: https://skillsfundingagency.atlassian.net/browse/AD-1213