### PR TITLE
CDN temp & classes - also added classes to _payeNotFound

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Web/Views/EmployerAccount/PayeError.cshtml
+++ b/src/SFA.DAS.EmployerAccounts.Web/Views/EmployerAccount/PayeError.cshtml
@@ -5,6 +5,8 @@
 @{ViewBag.Title = "PAYE scheme already in use";}
 @{ViewBag.HideNav = true; }
 @{ViewBag.GaData.Vpv = "/onboarding/address/update/page-extra-paye-error";}
+@{Layout = "~/Views/Shared/_Layout_CDN.cshtml"; }
+
 
 @if (ViewBag.NotFound)
 {
@@ -12,23 +14,23 @@
     ViewBag.Title = "PAYE scheme not linked to credentials";
 }
 
-<div class="grid-row">
-    <div class="column-two-thirds">
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
         @if (!ViewBag.NotFound)
         {
-            <h1 class="heading-xlarge">These details are already in use</h1>
-            <p>The details you added are already attached to a PAYE scheme.</p>
-            <p><a class="button" id="search_again" href="@Url.Action(ControllerConstants.GetApprenticeshipFundingActionName, ControllerConstants.EmployerAccountControllerName)">Use different details</a></p>
+        <h1 class="govuk-heading-xl">These details are already in use</h1>
+        <p class="govuk-body">The details you added are already attached to a <abbr>PAYE</abbr> scheme.</p>
+        <a href="@Url.Action(ControllerConstants.GetApprenticeshipFundingActionName, ControllerConstants.EmployerAccountControllerName)" class="govuk-button" id="search_again">Use different details</a>
         }
-        else 
+        else
         {
-            @Html.Partial("_PayeNotFound", @Url.Action("Gateway", "EmployerAccount"))
+        @Html.Partial("_PayeNotFound", @Url.Action("Gateway", "EmployerAccount"))
         }
     </div>
 </div>
 
 @section breadcrumb {
-    <div class="breadcrumbs">
-        <a href="@Url.Action(ControllerConstants.GetApprenticeshipFundingActionName, ControllerConstants.EmployerAccountControllerName)" class="back-link">Back</a>
+    <div class="govuk-breadcrumbs">
+        <a href="@Url.Action(ControllerConstants.GetApprenticeshipFundingActionName, ControllerConstants.EmployerAccountControllerName)" class="govuk-back-link">Back</a>
     </div>
 }

--- a/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_PayeNotFound.cshtml
+++ b/src/SFA.DAS.EmployerAccounts.Web/Views/Shared/_PayeNotFound.cshtml
@@ -1,11 +1,11 @@
 ﻿
 @model string
 
-
-<h1 class="heading-xlarge">No PAYE scheme found</h1>
-<p>The Government Gateway details you entered aren't linked to any PAYE schemes</p>
+<!-- remove .heading-xlarge and .button when ConfirmPayeScheme is upgraded to CDN -->
+<h1 class="govuk-heading-xl heading-xlarge">No <abbr>PAYE</abbr> scheme found</h1>
+<p>The Government Gateway details you entered aren't linked to any <abbr>PAYE</abbr> schemes</p>
 <p>
-    <a class="button" href="@Model">Enter different details</a>
+    <a class="govuk-button button" href="@Model">Enter different details</a>
 </p>
 
 


### PR DESCRIPTION
Page upgraded to CDN template/classes. A dependant file (_payeNotFound) has had GDS v3 classes added, but old classes also remain to support its use in another parent file which still uses v2 styles. This will support both during transition. 