### PR TITLE
Con 2237 amend eligibility logic to check for agreement version

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.UnitTests/Authorisation/EmployerFeatureAuthorisationHandlerTests.cs
+++ b/src/SFA.DAS.EmployerAccounts.UnitTests/Authorisation/EmployerFeatureAuthorisationHandlerTests.cs
@@ -146,9 +146,9 @@ namespace SFA.DAS.Authorization.Features.UnitTests.Handlers
                         StatusId = agreementStatus,
                         AccountLegalEntity = new AccountLegalEntity
                         {
-                            SignedAgreementVersion = agreementVersion
+                            SignedAgreementVersion = agreementStatus == EmployerAgreementStatus.Signed ? (int?)agreementVersion : null,
+                            PendingAgreementVersion = agreementStatus == EmployerAgreementStatus.Pending ? (int?)agreementVersion : null
                         }
-
                     }
                 }
             };


### PR DESCRIPTION
Any reason why we can't just just the currently signed agreement meets the min version required?