### PR TITLE
[TM-24] Pledges And Applications

### DIFF
--- a/azure/finance.template.json
+++ b/azure/finance.template.json
@@ -272,6 +272,30 @@
             }
         },
         {
+            "apiVersion": "2020-06-01",
+            "name": "apim-ui-product-subscription",
+            "resourceGroup": "[parameters('sharedApimResourceGroup')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'apim/apim-subscription.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "apimName": {
+                        "value": "[parameters('sharedApimName')]"
+                    },
+                    "subscriptionName": {
+                        "value": "[variables('uiAppServiceName')]"
+                    },
+                    "subscriptionScope": {
+                        "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('sharedApimResourceGroup'), '/providers/Microsoft.ApiManagement/service/', parameters('sharedApimName'), '/products/ManageApprenticeshipsOuterApi')]"
+                    }
+                }
+            }
+        },
+        {
             "condition": "[greater(length(parameters('apiCustomHostName')), 0)]",
             "apiVersion": "2020-06-01",
             "name": "api-app-service-certificate",
@@ -521,7 +545,7 @@
         },
         {
             "apiVersion": "2020-06-01",
-            "name": "apim-product-subscription",
+            "name": "apim-worker-product-subscription",
             "resourceGroup": "[parameters('sharedApimResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {

--- a/src/SFA.DAS.EmployerFinance.UnitTests/Infrastructure/OuterApiRequests/WhenBuildingGetPledgesRequest.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Infrastructure/OuterApiRequests/WhenBuildingGetPledgesRequest.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.EmployerFinance.Infrastructure.OuterApiRequests;
+
+namespace SFA.DAS.EmployerFinance.UnitTests.Infrastructure.OuterApiRequests
+{
+    public class WhenBuildingGetPledgesRequest
+    {
+        [Test]
+        public void Then_The_Url_Is_Correctly_Constructed()
+        {
+            var accountId = 123;
+
+            var actual = new GetPledgesRequest(accountId);
+
+            actual.GetUrl.Should().Be($"Pledges?accountId={accountId}");
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerFinance.UnitTests/Services/LevyTransferMatchingServiceTests/WhenIGetAPledgesCount.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Services/LevyTransferMatchingServiceTests/WhenIGetAPledgesCount.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerFinance.Infrastructure.OuterApiRequests;
+using SFA.DAS.EmployerFinance.Infrastructure.OuterApiResponses;
+using SFA.DAS.EmployerFinance.Interfaces.OuterApi;
+using SFA.DAS.EmployerFinance.Services;
+
+namespace SFA.DAS.EmployerFinance.UnitTests.Services.LevyTransferMatchingServiceTests
+{
+    public class WhenIGetAPledgesCount
+    {
+        private Mock<IApiClient> _mockApiClient;
+        private LevyTransferMatchingService _levyTransferMatchingService;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _mockApiClient = new Mock<IApiClient>();
+
+            _levyTransferMatchingService = new LevyTransferMatchingService(_mockApiClient.Object);
+        }
+
+        [Test]
+        public async Task ThenTheOuterApiIsCalledAndTotalPledgesForAccountReturned()
+        {
+            var expectedResult = 567;
+
+            var accountId = 123;
+
+            _mockApiClient
+                .Setup(x => x.Get<GetPledgesResponse>(It.Is<GetPledgesRequest>(y => y.GetUrl.EndsWith(accountId.ToString()))))
+                .ReturnsAsync(new GetPledgesResponse()
+                {
+                    TotalPledges = expectedResult,
+                });
+
+            var actualResult = await _levyTransferMatchingService.GetPledgesCount(accountId);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerFinance.Web/Controllers/TransfersController.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Controllers/TransfersController.cs
@@ -8,18 +8,18 @@ namespace SFA.DAS.EmployerFinance.Web.Controllers
     [DasAuthorize("EmployerFeature.TransfersMatching")]
     [RoutePrefix("accounts/{HashedAccountId}")] public class TransfersController : Controller
     {
-        private readonly TransfersOrchestrator _transfersOrcestrator;
+        private readonly TransfersOrchestrator _transfersOrchestrator;
 
         public TransfersController(TransfersOrchestrator transfersOrchestrator)
         {
-            _transfersOrcestrator = transfersOrchestrator;
+            _transfersOrchestrator = transfersOrchestrator;
         }
 
         [HttpGet]
         [Route("transfers")]
         public async Task<ActionResult> Index(string hashedAccountId)
         {
-            var viewModel = await _transfersOrcestrator.Index(hashedAccountId);
+            var viewModel = await _transfersOrchestrator.Index(hashedAccountId);
 
             return View(viewModel);
         }

--- a/src/SFA.DAS.EmployerFinance.Web/Controllers/TransfersController.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Controllers/TransfersController.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.EmployerFinance.Web.Controllers
         [Route("transfers")]
         public async Task<ActionResult> Index(string hashedAccountId)
         {
-            var viewModel = await _transfersOrcestrator.Index();
+            var viewModel = await _transfersOrcestrator.Index(hashedAccountId);
 
             return View(viewModel);
         }

--- a/src/SFA.DAS.EmployerFinance.Web/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/DependencyResolution/IoC.cs
@@ -37,6 +37,7 @@ namespace SFA.DAS.EmployerFinance.Web.DependencyResolution
                 c.AddRegistry<EmployerFeaturesAuthorizationRegistry>();
                 c.AddRegistry<EmployerUserRolesAuthorizationRegistry>();
                 c.AddRegistry<ContentApiClientRegistry>();
+                c.AddRegistry<ManageApprenticeshipsOuterApiRegistry>();
             });
         }
     }

--- a/src/SFA.DAS.EmployerFinance.Web/Orchestrators/TransfersOrchestrator.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Orchestrators/TransfersOrchestrator.cs
@@ -1,13 +1,17 @@
-﻿using SFA.DAS.Authorization.EmployerUserRoles.Options;
+﻿using System.Threading.Tasks;
+using SFA.DAS.Authorization.EmployerUserRoles.Options;
 using SFA.DAS.Authorization.Services;
+using SFA.DAS.EmployerFinance.Services;
 using SFA.DAS.EmployerFinance.Web.ViewModels;
-using System.Threading.Tasks;
+using SFA.DAS.HashingService;
 
 namespace SFA.DAS.EmployerFinance.Web.Orchestrators
 {
     public class TransfersOrchestrator
     {
         private readonly IAuthorizationService _authorizationService;
+        private readonly IHashingService _hashingService;
+        private readonly ILevyTransferMatchingService _levyTransferMatchingService;
 
         protected TransfersOrchestrator()
         {
@@ -15,20 +19,29 @@ namespace SFA.DAS.EmployerFinance.Web.Orchestrators
         }
 
         public TransfersOrchestrator(
-            IAuthorizationService authorizationService)
+            IAuthorizationService authorizationService,
+            IHashingService hashingService,
+            ILevyTransferMatchingService levyTransferMatchingService)
         {
             _authorizationService = authorizationService;
+            _hashingService = hashingService;
+            _levyTransferMatchingService = levyTransferMatchingService;
         }
 
-        public async Task<OrchestratorResponse<TransfersIndexViewModel>> Index()
+        public async Task<OrchestratorResponse<TransfersIndexViewModel>> Index(string hashedAccountId)
         {
             bool renderCreateTransfersPledgeButton = await _authorizationService.IsAuthorizedAsync(EmployerUserRole.OwnerOrTransactor);
+
+            var accountId = _hashingService.DecodeValue(hashedAccountId);
+
+            var pledgesCount = await _levyTransferMatchingService.GetPledgesCount(accountId);
 
             var viewModel = new OrchestratorResponse<TransfersIndexViewModel>()
             {
                 Data = new TransfersIndexViewModel()
                 {
                     RenderCreateTransfersPledgeButton = renderCreateTransfersPledgeButton,
+                    PledgesCount = pledgesCount,
                 }
             };
 

--- a/src/SFA.DAS.EmployerFinance.Web/ViewModels/TransfersIndexViewModel.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/ViewModels/TransfersIndexViewModel.cs
@@ -3,5 +3,6 @@
     public class TransfersIndexViewModel
     {
         public bool RenderCreateTransfersPledgeButton { get; set; }
+        public int PledgesCount { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
+++ b/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
@@ -3,19 +3,25 @@
 @{
     ViewBag.PageID = "transfers";
     ViewBag.Section = "finance";
-    ViewBag.Title = "Transfers";
+    ViewBag.Title = "Manage Transfers";
     ViewBag.AnalyticsData.Vpv = $"/finance/transfers";
     ViewBag.ZenDeskLabel = "eas-finance";
 }
 
-<h1 class="heading-xlarge">Your Transfers</h1>
+<h1 class="heading-xlarge">Manage Transfers</h1>
 
-@if (Model.Data.RenderCreateTransfersPledgeButton)
-{
-<div class="govuk-button-group">
-    <a class="govuk-button" data-module="govuk-button" href="@Url.LevyMatchingTransfersAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">My pledges</h2>
+        <p>Create a public funding pledge which is shown online so that businesses can apply to you for a transfer of funds.</p>
+        <div class="govuk-inset-text">You have <strong id="pledges-count">@Model.Data.PledgesCount</strong> transfer pledges.</div>
+        @if (Model.Data.RenderCreateTransfersPledgeButton)
+        {
+            <a class="govuk-button" data-module="govuk-button" href="@Url.LevyMatchingTransfersAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
+        }
+        <a href="@Url.LevyMatchingTransfersAction("pledges")" class="govuk-button govuk-button--secondary" data-module="govuk-button">View my transfer pledges and applications</a>
+    </div>
 </div>
-}
 
 @section breadcrumb {
     <div class="breadcrumbs">

--- a/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
+++ b/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
@@ -3,23 +3,26 @@
 @{
     ViewBag.PageID = "transfers";
     ViewBag.Section = "finance";
-    ViewBag.Title = "Manage Transfers";
+    ViewBag.Title = "Transfers";
     ViewBag.AnalyticsData.Vpv = $"/finance/transfers";
     ViewBag.ZenDeskLabel = "eas-finance";
 }
 
-<h1 class="heading-xlarge">Manage Transfers</h1>
-
+<h1 class="heading-xlarge">Transfers</h1>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m">My pledges</h2>
         <p>Create a public funding pledge which is shown online so that businesses can apply to you for a transfer of funds.</p>
-        <div class="govuk-inset-text">You have <strong id="pledges-count">@Model.Data.PledgesCount</strong> transfer pledges.</div>
-        @if (Model.Data.RenderCreateTransfersPledgeButton)
-        {
-            <a class="govuk-button" data-module="govuk-button" href="@Url.LevyMatchingTransfersAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
-        }
-        <a href="@Url.LevyMatchingTransfersAction("pledges")" class="govuk-button govuk-button--secondary" data-module="govuk-button">View my transfer pledges and applications</a>
+        <div class="panel panel-border-wide">
+            You have <strong>@Model.Data.PledgesCount</strong> transfer pledges.
+        </div>
+        <div class="">
+            @if (Model.Data.RenderCreateTransfersPledgeButton)
+            {
+                <a class="button" href="@Url.LevyMatchingTransfersAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
+            }
+            <a href="@Url.LevyMatchingTransfersAction("pledges")" class="button button-secondary">View my transfer pledges and applications</a>
+        </div>
     </div>
 </div>
 

--- a/src/SFA.DAS.EmployerFinance/Infrastructure/OuterApiRequests/GetPledgesRequest.cs
+++ b/src/SFA.DAS.EmployerFinance/Infrastructure/OuterApiRequests/GetPledgesRequest.cs
@@ -1,0 +1,16 @@
+﻿using SFA.DAS.EmployerFinance.Interfaces.OuterApi;
+
+namespace SFA.DAS.EmployerFinance.Infrastructure.OuterApiRequests
+{
+    public class GetPledgesRequest : IGetApiRequest
+    {
+        private readonly long _accountId;
+
+        public GetPledgesRequest(long accountId)
+        {
+            _accountId = accountId;
+        }
+
+        public string GetUrl => $"Pledges?accountId={_accountId}";
+    }
+}

--- a/src/SFA.DAS.EmployerFinance/Infrastructure/OuterApiResponses/GetPledgesResponse.cs
+++ b/src/SFA.DAS.EmployerFinance/Infrastructure/OuterApiResponses/GetPledgesResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.EmployerFinance.Infrastructure.OuterApiResponses
+{
+    public class GetPledgesResponse
+    {
+        public int TotalPledges { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerFinance/Services/ILevyTransferMatchingService.cs
+++ b/src/SFA.DAS.EmployerFinance/Services/ILevyTransferMatchingService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerFinance.Services
+{
+    public interface ILevyTransferMatchingService
+    {
+        Task<int> GetPledgesCount(long accountId);
+    }
+}

--- a/src/SFA.DAS.EmployerFinance/Services/LevyTransferMatchingService.cs
+++ b/src/SFA.DAS.EmployerFinance/Services/LevyTransferMatchingService.cs
@@ -1,0 +1,25 @@
+﻿namespace SFA.DAS.EmployerFinance.Services
+{
+    using System.Threading.Tasks;
+    using SFA.DAS.EmployerFinance.Infrastructure.OuterApiRequests;
+    using SFA.DAS.EmployerFinance.Infrastructure.OuterApiResponses;
+    using SFA.DAS.EmployerFinance.Interfaces.OuterApi;
+
+    public class LevyTransferMatchingService : ILevyTransferMatchingService
+    {
+        private readonly IApiClient _apiClient;
+
+        public LevyTransferMatchingService(
+            IApiClient apiClient)
+        {
+            _apiClient = apiClient;
+        }
+
+        public async Task<int> GetPledgesCount(long accountId)
+        {
+            var getPledgesResponse = await _apiClient.Get<GetPledgesResponse>(new GetPledgesRequest(accountId));
+
+            return getPledgesResponse.TotalPledges;
+        }
+    }
+}


### PR DESCRIPTION
Summary:

* Updates the finance sub-site LTM 'homepage' with the number of pledges created by the logged in account.
* **Note:** now includes the `ManageApprenticeshipsOuterApiRegistry` in the finance sub-site web project. This allows for the use of the existing `IApiClient` which talks to the MA Outer API, previously only used by MA jobs. This will require connectivity setting up between the finance sub-site and the MA Outer API.

See also:

* https://github.com/SkillsFundingAgency/das-employer-config/pull/962
* https://github.com/SkillsFundingAgency/das-employer-config/pull/968
* https://github.com/SkillsFundingAgency/das-apim-endpoints/pull/455
* https://github.com/SkillsFundingAgency/das-levy-transfer-matching-api/pull/22