### PR TITLE
TM-338 Fix transfer finances shown to non-levy employers

### DIFF
--- a/src/SFA.DAS.EmployerFinance.Web.UnitTests/Orchestrators/WhenGettingTransfers.cs
+++ b/src/SFA.DAS.EmployerFinance.Web.UnitTests/Orchestrators/WhenGettingTransfers.cs
@@ -42,7 +42,7 @@ namespace SFA.DAS.EmployerFinance.Web.UnitTests.Orchestrators
 
         [TestCase(true, true)]
         [TestCase(false, false)]
-        public async Task Only_Levy_Payer_Can_View_Pledges_Section(bool isLevyPayer, bool expectCanViewPledgesSection)
+        public async Task Only_Levy_Payer_Can_View_Pledges_Section(bool isLevyPayer, bool expectIsLevyEmployer)
         {
             _maService.Setup(o => o.GetIndex(AccountId)).ReturnsAsync(new GetIndexResponse());
 
@@ -50,7 +50,7 @@ namespace SFA.DAS.EmployerFinance.Web.UnitTests.Orchestrators
             
             var actual = await _orchestrator.GetIndexViewModel(HashedAccountId);
 
-            Assert.AreEqual(expectCanViewPledgesSection, actual.Data.CanViewPledgesSection);
+            Assert.AreEqual(expectIsLevyEmployer, actual.Data.IsLevyEmployer);
         }
 
         [TestCase(true, true)]

--- a/src/SFA.DAS.EmployerFinance.Web/Orchestrators/TransfersOrchestrator.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Orchestrators/TransfersOrchestrator.cs
@@ -52,7 +52,7 @@ namespace SFA.DAS.EmployerFinance.Web.Orchestrators
             {
                 Data = new IndexViewModel
                 {
-                    CanViewPledgesSection = employerType == ApprenticeshipEmployerType.Levy,
+                    IsLevyEmployer = employerType == ApprenticeshipEmployerType.Levy,
                     PledgesCount = indexTask.Result.PledgesCount,
                     ApplicationsCount = indexTask.Result.ApplicationsCount,
                     RenderCreateTransfersPledgeButton = renderCreateTransfersPledgeButtonTask.Result,                    

--- a/src/SFA.DAS.EmployerFinance.Web/ViewModels/Transfers/IndexViewModel.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/ViewModels/Transfers/IndexViewModel.cs
@@ -3,7 +3,7 @@
     public class IndexViewModel
     {
         public bool RenderCreateTransfersPledgeButton { get; set; }        
-        public bool CanViewPledgesSection { get; set; }
+        public bool IsLevyEmployer { get; set; }
         public int PledgesCount { get; set; }
         public int ApplicationsCount { get; set; }
         public decimal StartingTransferAllowance { get; set; }

--- a/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
+++ b/src/SFA.DAS.EmployerFinance.Web/Views/Transfers/Index.cshtml
@@ -15,45 +15,45 @@
 <h1 class="heading-xlarge">Manage transfers</h1>
 
 <div class="grid-row">
-    <div class="column-two-thirds">
-        <h2 class="heading-medium">My transfer finances</h2>
-        <p>This is a financial snapshot of what is available.</p>
-        <div class="finance-highlight">
-            <span class="bold-small">
-                Your transfer allowance
-                <span class="visually-hidden">for</span>
-                <abbr title="financial year">FY</abbr> @Model.Data.FinancialYearString
-            </span>
-            <span class="data-item bold-xlarge">@Model.Data.StartingTransferAllowance.ToString("C0", culture)</span>
-        </div>
-        <h2 class="heading-medium">Transfers allowance information</h2>
-        <p><strong>Your transfer allowance for this financial year (FY)</strong></p>
-        <p>This is calculated every year on 6 April and shows in your account after 20 April.</p>
-    </div>
 
-
-     @if (Html.IsAuthorized("EmployerFeature.FinanceDetails"))
-     {
+    @if (Model.Data.IsLevyEmployer)
+    {
         <div class="column-two-thirds">
-            <a href="/accounts/@Model.Data.HashedAccountID/transfers/financial-breakdown" class="button button-secondary">View my transfer finances</a>
-        </div>
-     }
-
-        @if (Model.Data.CanViewPledgesSection)
-        {
-            <div class="column-two-thirds">
-                <h2 class="heading-medium">My pledges</h2>
-                <p>Create a public funding pledge which is shown online so that businesses can apply to you for a transfer of funds.</p>
-                <div class="panel panel-border-wide">
-                    You have <strong>@Model.Data.PledgesCount</strong> transfer pledges.
-                </div>
-                @if (Model.Data.RenderCreateTransfersPledgeButton)
-                {
-                    <a class="button" href="@Url.LevyTransfersMatchingAccountAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
-                }
-                <a href="@Url.LevyTransfersMatchingAccountAction("pledges")" class="button button-secondary">View my transfer pledges and applications</a>
+            <h2 class="heading-medium">My transfer finances</h2>
+            <p>This is a financial snapshot of what is available.</p>
+            <div class="finance-highlight">
+                <span class="bold-small">
+                    Your transfer allowance
+                    <span class="visually-hidden">for</span>
+                    <abbr title="financial year">FY</abbr> @Model.Data.FinancialYearString
+                </span>
+                <span class="data-item bold-xlarge">@Model.Data.StartingTransferAllowance.ToString("C0", culture)</span>
             </div>
-        }
+            <h2 class="heading-medium">Transfers allowance information</h2>
+            <p><strong>Your transfer allowance for this financial year (FY)</strong></p>
+            <p>This is calculated every year on 6 April and shows in your account after 20 April.</p>
+        </div>
+
+         if (Html.IsAuthorized("EmployerFeature.FinanceDetails"))
+         {
+            <div class="column-two-thirds">
+                <a href="/accounts/@Model.Data.HashedAccountID/transfers/financial-breakdown" class="button button-secondary">View my transfer finances</a>
+            </div>
+         }
+
+        <div class="column-two-thirds">
+            <h2 class="heading-medium">My pledges</h2>
+            <p>Create a public funding pledge which is shown online so that businesses can apply to you for a transfer of funds.</p>
+            <div class="panel panel-border-wide">
+                You have <strong>@Model.Data.PledgesCount</strong> transfer pledges.
+            </div>
+            @if (Model.Data.RenderCreateTransfersPledgeButton)
+            {
+                <a class="button" href="@Url.LevyTransfersMatchingAccountAction("pledges/create/inform")" id="CreateTransfersPledgeButton">Create a transfers pledge</a>
+            }
+            <a href="@Url.LevyTransfersMatchingAccountAction("pledges")" class="button button-secondary">View my transfer pledges and applications</a>
+        </div>
+    }
 
         <div class="column-two-thirds">
             <h2 class="heading-medium">Apply for transfers funding</h2>


### PR DESCRIPTION
Moved if statement higher on the transfers view to hide irrelevant information from non-levy employers. Renamed bool to indicate source of check rather than target.