### PR TITLE
Remove temp suffix from finance apim subscriptions

### DIFF
--- a/azure/finance.template.json
+++ b/azure/finance.template.json
@@ -305,7 +305,7 @@
                         "value": "[parameters('sharedApimName')]"
                     },
                     "subscriptionName": {
-                        "value": "[concat(variables('uiAppServiceName'),'-temp')]"
+                        "value": "[variables('uiAppServiceName')]"
                     },
                     "subscriptionScope": {
                         "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('sharedApimResourceGroup'), '/providers/Microsoft.ApiManagement/service/', parameters('sharedApimName'), '/products/EmployerFinanceOuterApi')]"
@@ -609,7 +609,7 @@
                         "value": "[parameters('sharedApimName')]"
                     },
                     "subscriptionName": {
-                        "value": "[concat(variables('workerAppServiceName'),'-temp')]"
+                        "value": "[variables('workerAppServiceName')]"
                     },
                     "subscriptionScope": {
                         "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('sharedApimResourceGroup'), '/providers/Microsoft.ApiManagement/service/', parameters('sharedApimName'), '/products/EmployerFinanceOuterApi')]"


### PR DESCRIPTION
Temporary APIM subscriptions were created for the Finance UI and Worker
apps so that they could be moved from the ManageApprenticeshipsOuterApi
product to the EmployerFinanceOuterApi product.  The Managed subs are
being deleted so the EmployerFin subs can be recreated without the temp
suffix.